### PR TITLE
Ref #514 excel column starts with formula

### DIFF
--- a/twitter_rest_exporter.py
+++ b/twitter_rest_exporter.py
@@ -38,7 +38,7 @@ class BaseTwitterStatusTable(BaseTable):
                item['in_reply_to_screen_name'] or '',
                'http://twitter.com/{}/status/{}'.format(item["user"]["screen_name"], item["id_str"]),
                str(item['coordinates']['coordinates']) if item['coordinates'] else '',
-               item['text'].replace('\n', ' '),
+               "'"+item['text'].replace('\n', ' ')+"'",
                'Yes' if 'retweeted_status' in item else 'No',
                'Yes' if 'quoted_status_id' in item else 'No',
                ', '.join([user_mentions['screen_name'] for user_mentions in item['entities']['user_mentions']]),


### PR DESCRIPTION
Ref https://github.com/gwu-libraries/sfm-ui/issues/514
Currently, it's a tradeoff solution. 
### Pros
* The solution adds a single quote before and after the `text` field.  In the case, the excel can consider the string `=test` as a normal string. 
* `excel`, `csv` and `html` can display normal and view correctly.
### Cons
* The `text` has been modified since adding the quote. 
* unknown friendly use case , just like someone need the raw number of characters in the `text` field.
* unknown performance issue, not sure whether it has impacts on the efficiency of exporting.