### PR TITLE
Feature/fine grained volumes

### DIFF
--- a/docker/ci.docker-compose.yml
+++ b/docker/ci.docker-compose.yml
@@ -9,7 +9,11 @@ services:
   data:
       image: gwul/sfm-data:master
       volumes:
-           - /sfm-data
+           - /sfm-db-data
+           - /sfm-mq-data
+           - /sfm-export-data
+           - /sfm-containers-data
+           - /sfm-collection-set-data
       environment:
           - TZ=America/New_York
           - SFM_UID=900

--- a/docker/rest-exporter/invoke.sh
+++ b/docker/rest-exporter/invoke.sh
@@ -4,7 +4,7 @@ set -e
 sh /opt/sfm-setup/setup_reqs.sh
 
 echo "Waiting for dependencies"
-appdeps.py --wait-secs 60 --port-wait mq:5672 --port-wait api:8080 --file-wait /sfm-data/collection_set --file-wait /sfm-data/containers --file-wait /sfm-data/export \
+appdeps.py --wait-secs 60 --port-wait mq:5672 --port-wait api:8080 --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-containers-data/containers --file-wait /sfm-export-data/export \
 
 echo "Starting harvester"
-exec gosu sfm python twitter_rest_exporter.py --debug=$DEBUG service mq $RABBITMQ_USER $RABBITMQ_PASSWORD http://api:8080 /sfm-data/containers/$HOSTNAME
+exec gosu sfm python twitter_rest_exporter.py --debug=$DEBUG service mq $RABBITMQ_USER $RABBITMQ_PASSWORD http://api:8080 /sfm-containers-data/containers/$HOSTNAME

--- a/docker/rest-exporter/invoke.sh
+++ b/docker/rest-exporter/invoke.sh
@@ -4,7 +4,7 @@ set -e
 sh /opt/sfm-setup/setup_reqs.sh
 
 echo "Waiting for dependencies"
-appdeps.py --wait-secs 60 --port-wait mq:5672 --port-wait api:8080 --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-containers-data/containers --file-wait /sfm-export-data/export \
+appdeps.py --wait-secs 60 --port-wait ${SFM_RABBITMQ_HOST}:${SFM_RABBITMQ_PORT} --port-wait api:8080 --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-containers-data/containers --file-wait /sfm-export-data/export \
 
 echo "Starting harvester"
-exec gosu sfm python twitter_rest_exporter.py --debug=$DEBUG service mq $RABBITMQ_USER $RABBITMQ_PASSWORD http://api:8080 /sfm-containers-data/containers/$HOSTNAME
+exec gosu sfm python twitter_rest_exporter.py --debug=$DEBUG service $SFM_RABBITMQ_HOST $SFM_RABBITMQ_USER $SFM_RABBITMQ_PASSWORD http://api:8080 /sfm-containers-data/containers/$HOSTNAME

--- a/docker/rest-harvester/invoke.sh
+++ b/docker/rest-harvester/invoke.sh
@@ -4,7 +4,7 @@ set -e
 sh /opt/sfm-setup/setup_reqs.sh
 
 echo "Waiting for dependencies"
-appdeps.py --wait-secs 60 --port-wait mq:5672 --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-collection-set-data/containers
+appdeps.py --wait-secs 60 --port-wait ${SFM_RABBITMQ_HOST}:${SFM_RABBITMQ_PORT} --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-collection-set-data/containers
 
 echo "Starting harvester"
-exec gosu sfm python twitter_harvester.py --debug=$DEBUG --debug-warcprox=$DEBUG_WARCPROX service mq $RABBITMQ_USER $RABBITMQ_PASSWORD /sfm-containers-data/containers/$HOSTNAME --tries=$HARVEST_TRIES --priority-queues=$PRIORITY_QUEUES
+exec gosu sfm python twitter_harvester.py --debug=$DEBUG --debug-warcprox=$DEBUG_WARCPROX service $SFM_RABBITMQ_HOST $SFM_RABBITMQ_USER $SFM_RABBITMQ_PASSWORD /sfm-containers-data/containers/$HOSTNAME --tries=$HARVEST_TRIES --priority-queues=$PRIORITY_QUEUES

--- a/docker/rest-harvester/invoke.sh
+++ b/docker/rest-harvester/invoke.sh
@@ -4,7 +4,7 @@ set -e
 sh /opt/sfm-setup/setup_reqs.sh
 
 echo "Waiting for dependencies"
-appdeps.py --wait-secs 60 --port-wait mq:5672 --file-wait /sfm-data/collection_set --file-wait /sfm-data/containers
+appdeps.py --wait-secs 60 --port-wait mq:5672 --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-collection-set-data/containers
 
 echo "Starting harvester"
-exec gosu sfm python twitter_harvester.py --debug=$DEBUG --debug-warcprox=$DEBUG_WARCPROX service mq $RABBITMQ_USER $RABBITMQ_PASSWORD /sfm-data/containers/$HOSTNAME --tries=$HARVEST_TRIES --priority-queues=$PRIORITY_QUEUES
+exec gosu sfm python twitter_harvester.py --debug=$DEBUG --debug-warcprox=$DEBUG_WARCPROX service mq $RABBITMQ_USER $RABBITMQ_PASSWORD /sfm-containers-data/containers/$HOSTNAME --tries=$HARVEST_TRIES --priority-queues=$PRIORITY_QUEUES

--- a/docker/stream-exporter/invoke.sh
+++ b/docker/stream-exporter/invoke.sh
@@ -4,7 +4,7 @@ set -e
 sh /opt/sfm-setup/setup_reqs.sh
 
 echo "Waiting for dependencies"
-appdeps.py --wait-secs 60 --port-wait mq:5672 --port-wait api:8080 --file-wait /sfm-data/collection_set --file-wait /sfm-data/containers --file-wait /sfm-data/export \
+appdeps.py --wait-secs 60 --port-wait mq:5672 --port-wait api:8080 --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-containers-data/containers --file-wait /sfm-export-data/export \
 
 echo "Starting harvester"
-exec gosu sfm python twitter_stream_exporter.py --debug=$DEBUG service mq $RABBITMQ_USER $RABBITMQ_PASSWORD http://api:8080 /sfm-data/containers/$HOSTNAME
+exec gosu sfm python twitter_stream_exporter.py --debug=$DEBUG service mq $RABBITMQ_USER $RABBITMQ_PASSWORD http://api:8080 /sfm-containers-data/containers/$HOSTNAME

--- a/docker/stream-exporter/invoke.sh
+++ b/docker/stream-exporter/invoke.sh
@@ -4,7 +4,7 @@ set -e
 sh /opt/sfm-setup/setup_reqs.sh
 
 echo "Waiting for dependencies"
-appdeps.py --wait-secs 60 --port-wait mq:5672 --port-wait api:8080 --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-containers-data/containers --file-wait /sfm-export-data/export \
+appdeps.py --wait-secs 60 --port-wait ${SFM_RABBITMQ_HOST}:${SFM_RABBITMQ_PORT} --port-wait api:8080 --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-containers-data/containers --file-wait /sfm-export-data/export \
 
 echo "Starting harvester"
-exec gosu sfm python twitter_stream_exporter.py --debug=$DEBUG service mq $RABBITMQ_USER $RABBITMQ_PASSWORD http://api:8080 /sfm-containers-data/containers/$HOSTNAME
+exec gosu sfm python twitter_stream_exporter.py --debug=$DEBUG service $SFM_RABBITMQ_HOST $SFM_RABBITMQ_USER $SFM_RABBITMQ_PASSWORD http://api:8080 /sfm-containers-data/containers/$HOSTNAME

--- a/docker/stream-harvester/invoke.sh
+++ b/docker/stream-harvester/invoke.sh
@@ -6,11 +6,11 @@ set -e
 sh /opt/sfm-setup/setup_reqs.sh
 
 echo "Waiting for dependencies"
-appdeps.py --wait-secs 60 --port-wait mq:5672 --file-wait /sfm-data/collection_set --file-wait /sfm-data/containers
+appdeps.py --wait-secs 60 --port-wait mq:5672 --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-collection-set-data/containers
 
 echo "Starting supervisor"
 supervisord -c /etc/supervisor/supervisord.conf
 
 echo "Starting stream consumer"
 # exec makes this take the pid of the script, which should be pid 1.
-exec stream_consumer.py mq $RABBITMQ_USER $RABBITMQ_PASSWORD twitter_harvester harvest.start.twitter.twitter_filter,harvest.start.twitter.twitter_sample /opt/sfm-twitter-harvester/twitter_harvester.py /sfm-data/containers/$HOSTNAME --debug=$DEBUG --debug-warcprox=$DEBUG_WARCPROX --tries=$HARVEST_TRIES
+exec stream_consumer.py mq $RABBITMQ_USER $RABBITMQ_PASSWORD twitter_harvester harvest.start.twitter.twitter_filter,harvest.start.twitter.twitter_sample /opt/sfm-twitter-harvester/twitter_harvester.py /sfm-containers-data/containers/$HOSTNAME --debug=$DEBUG --debug-warcprox=$DEBUG_WARCPROX --tries=$HARVEST_TRIES

--- a/docker/stream-harvester/invoke.sh
+++ b/docker/stream-harvester/invoke.sh
@@ -6,11 +6,11 @@ set -e
 sh /opt/sfm-setup/setup_reqs.sh
 
 echo "Waiting for dependencies"
-appdeps.py --wait-secs 60 --port-wait mq:5672 --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-collection-set-data/containers
+appdeps.py --wait-secs 60 --port-wait ${SFM_RABBITMQ_HOST}:${SFM_RABBITMQ_PORT} --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-collection-set-data/containers
 
 echo "Starting supervisor"
 supervisord -c /etc/supervisor/supervisord.conf
 
 echo "Starting stream consumer"
 # exec makes this take the pid of the script, which should be pid 1.
-exec stream_consumer.py mq $RABBITMQ_USER $RABBITMQ_PASSWORD twitter_harvester harvest.start.twitter.twitter_filter,harvest.start.twitter.twitter_sample /opt/sfm-twitter-harvester/twitter_harvester.py /sfm-containers-data/containers/$HOSTNAME --debug=$DEBUG --debug-warcprox=$DEBUG_WARCPROX --tries=$HARVEST_TRIES
+exec stream_consumer.py $SFM_RABBITMQ_HOST $SFM_RABBITMQ_USER $SFM_RABBITMQ_PASSWORD twitter_harvester harvest.start.twitter.twitter_filter,harvest.start.twitter.twitter_sample /opt/sfm-twitter-harvester/twitter_harvester.py /sfm-containers-data/containers/$HOSTNAME --debug=$DEBUG --debug-warcprox=$DEBUG_WARCPROX --tries=$HARVEST_TRIES

--- a/tests/test_twitter_harvester.py
+++ b/tests/test_twitter_harvester.py
@@ -436,7 +436,7 @@ class TestTwitterHarvesterIntegration(tests.TestCase):
             shutil.rmtree(self.harvest_path, ignore_errors=True)
 
     def test_search(self):
-        self.harvest_path = "/sfm-data/collection_set/test_collection/test_1"
+        self.harvest_path = "/sfm-collection-set-data/collection_set/test_collection/test_1"
         harvest_msg = {
             "id": "test:1",
             "type": "twitter_search",
@@ -494,7 +494,7 @@ class TestTwitterHarvesterIntegration(tests.TestCase):
             self.assertTrue(self._wait_for_message(self.warc_created_queue, connection))
 
     def test_filter(self):
-        self.harvest_path = "/sfm-data/collection_set/test_collection/test_2"
+        self.harvest_path = "/sfm-collection-set-data/collection_set/test_collection/test_2"
         harvest_msg = {
             "id": "test:2",
             "type": "twitter_filter",
@@ -561,7 +561,7 @@ class TestTwitterHarvesterIntegration(tests.TestCase):
             self.assertTrue(self._wait_for_message(self.warc_created_queue, connection))
 
     def test_sample(self):
-        self.harvest_path = "/sfm-data/collection_set/test_collection/test_3"
+        self.harvest_path = "/sfm-collection-set-data/collection_set/test_collection/test_3"
         harvest_msg = {
             "id": "test:3",
             "type": "twitter_sample",
@@ -619,7 +619,7 @@ class TestTwitterHarvesterIntegration(tests.TestCase):
             self.assertTrue(self._wait_for_message(self.warc_created_queue, connection))
 
     def test_user_timeline(self):
-        self.harvest_path = "/sfm-data/collection_set/test_collection/test_4"
+        self.harvest_path = "/sfm-collection-set-data/collection_set/test_collection/test_4"
         harvest_msg = {
             "id": "test:4",
             "type": "twitter_user_timeline",


### PR DESCRIPTION
This PR covers changes related to the issue https://github.com/gwu-libraries/sfm-ui/issues/1051
as well as the PRs https://github.com/gwu-libraries/sfm-ui/pull/1050 and https://github.com/gwu-libraries/sfm-ui/pull/1055

The hard coded service name of RabbitMQ is replaced with a variable
and instead of using a single `/sfm-data` volume more fine grained volumes such as `/sfm-mq-data` are used.

Similar changes need to be applied to other SFM harvesters.
However, as we do not make use of other harvesters in our setup at the moment we do not have these changes.