### PR TITLE
T1059 travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 - docker-compose --version
 - docker-compose -f docker/ci.docker-compose.yml pull
 - docker-compose -f docker/ci.docker-compose.yml up -d
-- sleep 30 
+- sleep 30
 - docker exec docker_twitterrestharvester_1 python -m unittest discover
 install: pip install -r requirements/common.txt -r requirements/master.txt
 script: python -m unittest discover

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - docker-compose --version
 - docker-compose -f docker/ci.docker-compose.yml pull
 - docker-compose -f docker/ci.docker-compose.yml up -d
-- sleep 30
+- sleep 90 
 - docker exec docker_twitterrestharvester_1 python -m unittest discover
 install: pip install -r requirements/common.txt -r requirements/master.txt
 script: python -m unittest discover

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - docker-compose --version
 - docker-compose -f docker/ci.docker-compose.yml pull
 - docker-compose -f docker/ci.docker-compose.yml up -d
-- sleep 180 
+- sleep 360 
 - docker exec docker_twitterrestharvester_1 python -m unittest discover
 install: pip install -r requirements/common.txt -r requirements/master.txt
 script: python -m unittest discover

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - docker-compose --version
 - docker-compose -f docker/ci.docker-compose.yml pull
 - docker-compose -f docker/ci.docker-compose.yml up -d
-- sleep 90 
+- sleep 180 
 - docker exec docker_twitterrestharvester_1 python -m unittest discover
 install: pip install -r requirements/common.txt -r requirements/master.txt
 script: python -m unittest discover

--- a/docker/ci.docker-compose.yml
+++ b/docker/ci.docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   rabbit:
-      image: rabbitmq@sha256:397382d2b222f3a298a6c74e93f348fb16f9a7fde2c02ba14122624d852daae3
+      image: rabbitmq@sha256:d374d705b3f16e3f0ee34ea14d8599cb4c1f1604ae6deef5fefbaf063d0bb9c6
       environment:
           - TZ=America/New_York
           - RABBITMQ_DEFAULT_USER=sfm_user

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,7 +4,7 @@ import os
 import socket
 
 try:
-    from test_config import *
+    from .test_config import *
 except ImportError:
     TWITTER_CONSUMER_KEY = os.environ.get("TWITTER_CONSUMER_KEY", "fake")
     TWITTER_CONSUMER_SECRET = os.environ.get("TWITTER_CONSUMER_SECRET", "fake")
@@ -15,11 +15,11 @@ test_config_available = True if TWITTER_CONSUMER_KEY != "fake" and TWITTER_CONSU
                                 and TWITTER_ACCESS_TOKEN != "fake" and TWITTER_ACCESS_TOKEN_SECRET != "fake" else False
 
 mq_port_available = True
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-try:
-    s.connect(("mq", 5672))
-except socket.error:
-    mq_port_available = False
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    try:
+        s.connect(("mq", 5672))
+    except socket.error:
+        mq_port_available = False
 
 mq_username = os.environ.get("RABBITMQ_USER")
 mq_password = os.environ.get("RABBITMQ_PASSWORD")

--- a/tests/test_twitter_harvester.py
+++ b/tests/test_twitter_harvester.py
@@ -126,7 +126,7 @@ class TestTwitterHarvester(tests.TestCase):
         self.assertDictEqual({"tweets": 1}, self.harvester.result.harvest_counter)
 
     @patch("twitter_harvester.Twarc", autospec=True)
-    def test_search(self, mock_twarc_class):
+    def test_new_search(self, mock_twarc_class):
         # The new search style has separate query and geocode parameters for search. However, the legacy
         # style is still accepted.
         mock_twarc = MagicMock(spec=Twarc)

--- a/tests/test_twitter_rest_warc_iter.py
+++ b/tests/test_twitter_rest_warc_iter.py
@@ -12,27 +12,27 @@ class TestTwitterRestWarcIter(tests.TestCase):
     def test_no_limit(self):
         warc_iter = TwitterRestWarcIter(self.filepaths)
         tweets = list(warc_iter)
-        self.assertEquals(1473, len(tweets))
-        self.assertEquals("721345764362948609", tweets[0][1])
+        self.assertEqual(1473, len(tweets))
+        self.assertEqual("721345764362948609", tweets[0][1])
         # Datetime is aware
         self.assertIsNotNone(tweets[0][2].tzinfo)
 
     def test_limit(self):
         warc_iter = TwitterRestWarcIter(self.filepaths, limit_user_ids=("481186914", "999999"))
-        self.assertEquals(244, len(list(warc_iter)))
+        self.assertEqual(244, len(list(warc_iter)))
 
         warc_iter = TwitterRestWarcIter(self.filepaths, limit_user_ids=("999999",))
-        self.assertEquals(0, len(list(warc_iter)))
+        self.assertEqual(0, len(list(warc_iter)))
 
     def test_ignore_errors(self):
-        self.assertEquals(0, len(list(TwitterRestWarcIter._item_iter(None,
+        self.assertEqual(0, len(list(TwitterRestWarcIter._item_iter(None,
                                                                      'https://api.twitter.com/1.1/statuses/'
                                                                      'user_timeline.json',
                                                                      {'errors': [
                                                                          {'message': 'Rate limit exceeded',
                                                                           'code': 88}]}))))
 
-        self.assertEquals(0, len(list(TwitterRestWarcIter._item_iter(None,
+        self.assertEqual(0, len(list(TwitterRestWarcIter._item_iter(None,
                                                                      'https://api.twitter.com/1.1/statuses/'
                                                                      'user_timeline.json',
                                                                      {'request': '/1.1/statuses/user_timeline.json',


### PR DESCRIPTION
Corrects errors with Travis build caused by docker-compose version and addresses deprecated tests. To test, run unit tests locally after creating a `test_config.py` file with a set of Twitter credentials. Also, you can review the Travis build log which now has updated Twitter app credentials. 