### PR TITLE
Fixes #1080. Updates paths in supervisor files to new dirs.

### DIFF
--- a/docker/stream-harvester/invoke.sh
+++ b/docker/stream-harvester/invoke.sh
@@ -8,6 +8,13 @@ sh /opt/sfm-setup/setup_reqs.sh
 echo "Waiting for dependencies"
 appdeps.py --wait-secs 60 --port-wait ${SFM_RABBITMQ_HOST}:${SFM_RABBITMQ_PORT} --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-containers-data/containers
 
+# if filter streams were running under supervisor in 2.3 or earlier, replace old sfm-data paths with 2.4+ paths
+if  [ "$(ls -A /etc/supervisor/conf.d)" ]
+then
+  sed -i.bak 's/sfm-data/sfm-containers-data/' /etc/supervisor/conf.d/*.conf
+  sed -i.bak 's/sfm-data/sfm-collection-set-data/' /etc/supervisor/conf.d/*.json
+fi
+
 echo "Starting supervisor"
 supervisord -c /etc/supervisor/supervisord.conf
 


### PR DESCRIPTION
See description of issue this addresses in https://github.com/gwu-libraries/sfm-ui/issues/1080

Review manually or test:
1) Set up a 2.3 instance
2) Run a filter stream collection
3) stop and upgrade SFM as in documentation:
`docker-compose stop -t 180 twitterstreamharvester`
`docker-compose stop`
4) Migrate to SFM 2.4 
5) Confirm that the twitterstreamharvester container comes up with no errors in the logs and that the filter stream has restarted itself successfully. Review `/etc/supervisor/conf.d/` files to see that paths were updated. 
