### PR TITLE
Twitter v2 API: fix unit tests, update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 # sfm-twitter-harvester
-Harvesters for twitter content as part of [Social Feed Manager](http://gwu-libraries.github.io/sfm-ui).
+Harvesters for twitter content as part of [Social Feed Manager](https://gwu-libraries.github.io/sfm-ui).
 
 [![Build Status](https://travis-ci.org/gwu-libraries/sfm-twitter-harvester.svg?branch=master)](https://travis-ci.org/gwu-libraries/sfm-twitter-harvester)
 
-Provides harvesters for Twitter [REST API](https://dev.twitter.com/rest/public) and [Streaming API](https://dev.twitter.com/streaming/overview).
+Provides harvesters for [Twitter v1 and v2 APIs](https://developer.twitter.com/en/docs/twitter-api/).
 
 Harvesting is performed by [Twarc](https://github.com/edsu/twarc) and captured by a modified version of [WarcProx](https://github.com/gwu-libraries/warcprox).
 
 ## Development
 
-For information on development and running tests, see the [development documentation](http://sfm.readthedocs.io/en/latest/development.html).
+For information on development and running tests, see the [development documentation](https://sfm.readthedocs.io/en/latest/development.html).
 
-When running tests, provide Twitter credentials either as a `test_config.py` file or environment variables (`TWITTER_CONSUMER_KEY`,
-`TWITTER_CONSUMER_SECRET`, `TWITTER_ACCESS_TOKEN` and `TWITTER_ACCESS_TOKEN_SECRET`).  An example `test_config.py` looks like:
+When running tests, provide Twitter credentials either as a `test_config.py` file or environment variables (`TWITTER_CONSUMER_KEY`, `TWITTER_CONSUMER_SECRET`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_TOKEN_SECRET` and for the Twitter v2 API `TWITTER_BEARER_TOKEN`).  An example `test_config.py` looks like:
 
         TWITTER_CONSUMER_KEY = "EHdoTksBfgGflP5nUalEfhaeo"
         TWITTER_CONSUMER_SECRET = "ZtUpemtBkf2cEmaqiy52Dd343ihFu9PAiLebuMOmqN0QtXeAlen"
         TWITTER_ACCESS_TOKEN = "411876914-c2yZjbk1np0Z5MWEFYYQKSQNFFGBXd8T4k90YkJl"
         TWITTER_ACCESS_TOKEN_SECRET = "jK9QOmn5VRF5mfgAN6
+        TWITTER_BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAAAn6cn6sBA57n6uaABRalD7AIFEABxzAoj8F5MV%3DIxlklPFn3b1CDoLu0tSfbDaP6xvOo8ueJkbzH5u6nu0urAQwh6'
+
+If only the v2 API is used, it is sufficient to configure the variable `TWITTER_BEARER_TOKEN`, the other variable need to be defined but may be empty.
 
 ## Running as a service
 ### Running as a service for the REST API.

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-twarc==2.8.2
+twarc==2.10.4
 python-dateutil==2.8.2
 
 # Master support Py3, but no release. This should be in sfm-utils setup.py once released.

--- a/tests/test_twitter_harvester.py
+++ b/tests/test_twitter_harvester.py
@@ -522,7 +522,7 @@ class TestTwitterHarvester2(tests.TestCase):
     def test_user_timeline_2(self, mock_twarc_class):
         mock_twarc = MagicMock(spec=Twarc2)
         # Expecting 2 user timelines. First returns 2 tweets. Second returns none.
-        mock_twarc.timeline.side_effect = [[join_tweets(tweet1_2, tweet2_2), ()]]
+        mock_twarc.timeline.side_effect = [[join_tweets(tweet1_2, tweet2_2)], [()]]
         # Expecting 2 calls to get for user lookup
         mock_response1 = MagicMock()
         mock_response1.status_code = 200
@@ -551,7 +551,7 @@ class TestTwitterHarvester2(tests.TestCase):
 
         mock_twarc = MagicMock(spec=Twarc2)
         # Expecting 2 timelines. First returns 1 tweets. Second returns none.
-        mock_twarc.timeline.side_effect = [[tweet2_2, ()]]
+        mock_twarc.timeline.side_effect = [[tweet2_2], [()]]
         # Expecting 2 calls to get for user lookup
         mock_response1 = MagicMock()
         mock_response1.status_code = 200

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -351,9 +351,9 @@ class TwitterHarvester(BaseHarvester):
                 log.debug("Stopping since stop event set.")
                 break
 
-    def _harvest_tweets_2(self, tweets, limit=None):
+    def _harvest_tweets_2(self, pages, limit=None):
         # max_tweet_id = None
-        for page in tweets:
+        for page in pages:
             if 'data' not in page:
                 return
             for count, tweet in enumerate(page['data']):
@@ -363,13 +363,9 @@ class TwitterHarvester(BaseHarvester):
                 if limit and self.result.harvest_counter["tweets"] >= limit:
                     log.debug("Stopping since limit reached.")
                     self.stop_harvest_seeds_event.set()
-                    #break
                 if self.stop_harvest_seeds_event.is_set():
                     log.debug("Stopping since stop event set.")
-                    break
-            else:
-                continue
-            break
+                    return
 
     def process_warc(self, warc_filepath):
         # Dispatch message based on type.

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -96,7 +96,7 @@ class TwitterHarvester(BaseHarvester):
 
         query, geocode = self._search_parameters()
         self._harvest_tweets(self.twarc.search(query, geocode=geocode, since_id=since_id))
-    
+
     def search_2(self):
         assert len(self.message.get("seeds", [])) == 1
 
@@ -129,11 +129,11 @@ class TwitterHarvester(BaseHarvester):
             geocode = self.message["seeds"][0]["token"].get("geocode")
             if self.message["seeds"][0]["token"].get("start_time"):
                 start_time = datetime.fromisoformat(self.message["seeds"][0]["token"]["start_time"]).astimezone(pytz.utc)
-            else: 
+            else:
                 start_time = None
             if self.message["seeds"][0]["token"].get("end_time"):
                 end_time = datetime.fromisoformat(self.message["seeds"][0]["token"]["end_time"]).astimezone(pytz.utc)
-            else: 
+            else:
                 end_time = None
             limit = self.message["seeds"][0]["token"].get("limit")
         else:
@@ -323,7 +323,7 @@ class TwitterHarvester(BaseHarvester):
             else:
                 raise e
         return result, user
- 
+
     @staticmethod
     def _has_error_code(resp, code):
         if isinstance(code, int):
@@ -368,7 +368,7 @@ class TwitterHarvester(BaseHarvester):
                     log.debug("Stopping since stop event set.")
                     break
             else:
-                continue  
+                continue
             break
 
     def process_warc(self, warc_filepath):
@@ -397,7 +397,7 @@ class TwitterHarvester(BaseHarvester):
 
         since_id = self.state_store.get_state(__name__,
                                               u"{}.since_id".format(self._search_id())) if incremental else None
-       
+
         max_tweet_id = self._process_tweets(TwitterRestWarcIter(warc_filepath))
 
         # Update state store
@@ -431,7 +431,7 @@ class TwitterHarvester(BaseHarvester):
                     self.state_store.set_state(__name__, key,
                                                max(self.state_store.get_state(__name__, key) or 0, tweet.get("id")))
                 self._process_tweet(tweet)
- 
+
     def process_user_timeline_warc_2(self, warc_filepath):
         incremental = self.message.get("options", {}).get("incremental", False)
 
@@ -460,7 +460,7 @@ class TwitterHarvester(BaseHarvester):
                 max_tweet_id = max(max_tweet_id or 0, tweet.get("id"))
                 self._process_tweet(tweet)
         return max_tweet_id
-    
+
     def _process_tweets_2(self, warc_iter):
         max_tweet_id = None
 


### PR DESCRIPTION
- v2 harvester
  - simplify iteration over result pages and tweets
  - fix user-timeline unit tests
- upgrade Twarc to 2.10.4
- update README
  - note about support for v2 API
  - add bearer token (v2 API)
  - update links
  - note: this removes the separate links for the REST and Streaming API - I haven't found dedicated landing pages for the two and the [Streaming API is going to be retired in Oct 2022](https://twittercommunity.com/t/deprecation-announcement-removing-compliance-messages-from-statuses-filter-and-retiring-statuses-sample-from-the-twitter-api-v1-1/170500)