### PR TITLE
Twitter REST WARC iterator: add iterator class automatically detecting response API version

### DIFF
--- a/twitter_rest_warc_iter.py
+++ b/twitter_rest_warc_iter.py
@@ -13,6 +13,8 @@ SEARCH_URL = "https://api.twitter.com/1.1/search/tweets.json"
 TIMELINE_URL = "https://api.twitter.com/1.1/statuses/user_timeline.json"
 SEARCH_URL_2 = re.compile(r"https://api.twitter.com/2/tweets/(?:search/(?:recent|all)|sample/stream)")
 TIMELINE_URL_2 = re.compile(r"https://api.twitter.com/2/users/[^/]+/(?:tweets|mentions)")
+API_V1 = "https://api.twitter.com/1.1/"
+API_V2 = "https://api.twitter.com/2/"
 
 class TwitterRestWarcIter(BaseWarcIter):
     def __init__(self, filepaths, limit_user_ids=None):
@@ -23,6 +25,10 @@ class TwitterRestWarcIter(BaseWarcIter):
         return url.startswith(SEARCH_URL) or url.startswith(TIMELINE_URL)
 
     def _item_iter(self, url, json_obj):
+        return TwitterRestWarcIter._get_iter(url, json_obj)
+
+    @staticmethod
+    def _get_iter(url, json_obj):
         # Ignore error messages
         if isinstance(json_obj, dict) and ('error' in json_obj or 'errors' in json_obj):
             return
@@ -51,6 +57,10 @@ class TwitterRestWarcIter2(BaseWarcIter):
         return SEARCH_URL_2.match(url) or TIMELINE_URL_2.match(url)
 
     def _item_iter(self, url, json_obj):
+        return TwitterRestWarcIter2._get_iter(url, json_obj)
+
+    @staticmethod
+    def _get_iter(url, json_obj):
         # Ignore error messages
         if not isinstance(json_obj, dict) or not 'data' in json_obj:
             return
@@ -68,6 +78,33 @@ class TwitterRestWarcIter2(BaseWarcIter):
             return True
         return False
 
+class TwitterRestWarcIterAutoVersion(BaseWarcIter):
+    def __init__(self, filepaths, limit_user_ids=None):
+        BaseWarcIter.__init__(self, filepaths)
+        self.limit_user_ids = limit_user_ids
+
+    def _select_record(self, url):
+        if url.startswith(API_V1):
+            return url.startswith(SEARCH_URL) or url.startswith(TIMELINE_URL)
+        elif url.startswith(API_V2):
+            return SEARCH_URL_2.match(url) or TIMELINE_URL_2.match(url)
+        return False
+
+    def _item_iter(self, url, json_obj):
+        if url.startswith(API_V1):
+            return TwitterRestWarcIter._get_iter(url, json_obj)
+        if url.startswith(API_V2):
+            return TwitterRestWarcIter2._get_iter(url, json_obj)
+
+    @staticmethod
+    def item_types():
+        return ["twitter_status"]
+
+    def _select_item(self, item):
+        if not self.limit_user_ids or item.get("user", {}).get("id_str") in self.limit_user_ids:
+            return True
+        return False
+
 
 if __name__ == "__main__":
-    TwitterRestWarcIter.main(TwitterRestWarcIter)
+    TwitterRestWarcIterAutoVersion.main(TwitterRestWarcIterAutoVersion)


### PR DESCRIPTION
Add a new iterator class to twitter_rest_warc_iter.py which automatically detects the API version of the Twitter response. The new class is used if the iterator is run as top-level "__main__" script, in order to process WARC files no matter whether they've been written from a v1 or v2 harvester.