### PR TITLE
T1103 exporter v2

### DIFF
--- a/Dockerfile-rest-exporter-v2
+++ b/Dockerfile-rest-exporter-v2
@@ -1,0 +1,13 @@
+# Python 3.8.12:buster
+FROM gwul/sfm-base@sha256:0b80a3d3562cdb4d631fbb55b9bd24889312838cbd27cd33e14cc0c18405f007
+MAINTAINER Social Feed Manager <sfm@gwu.edu>
+
+ADD . /opt/sfm-twitter-harvester/
+WORKDIR /opt/sfm-twitter-harvester
+RUN pip install -r requirements/common.txt -r requirements/release.txt
+
+ADD docker/rest-exporter/invoke.sh /opt/sfm-setup/
+RUN chmod +x /opt/sfm-setup/invoke.sh
+# invoke with argument to launch the Twitter v2 exporter
+ENTRYPOINT ["/opt/sfm-setup/invoke.sh"] 
+CMD ["2"]

--- a/docker/rest-exporter/invoke.sh
+++ b/docker/rest-exporter/invoke.sh
@@ -2,9 +2,8 @@
 set -e
 
 sh /opt/sfm-setup/setup_reqs.sh
-
 echo "Waiting for dependencies"
 appdeps.py --wait-secs 60 --port-wait ${SFM_RABBITMQ_HOST}:${SFM_RABBITMQ_PORT} --port-wait api:8080 --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-containers-data/containers --file-wait /sfm-export-data/export \
 
 echo "Starting harvester"
-exec gosu sfm python twitter_rest_exporter.py --debug=$DEBUG service $SFM_RABBITMQ_HOST $SFM_RABBITMQ_USER $SFM_RABBITMQ_PASSWORD http://api:8080 /sfm-containers-data/containers/$HOSTNAME
+exec gosu sfm python twitter_rest_exporter.py --debug=$DEBUG service $SFM_RABBITMQ_HOST $SFM_RABBITMQ_USER $SFM_RABBITMQ_PASSWORD http://api:8080 /sfm-containers-data/containers/$HOSTNAME --twitter_version=${1:-1}

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,5 +1,6 @@
 twarc==2.8.2
 python-dateutil==2.8.2
+#twarc-csv==0.5.2
 
 # Master support Py3, but no release. This should be in sfm-utils setup.py once released.
 git+https://github.com/Supervisor/supervisor

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,5 +1,5 @@
-twarc==1.12.1
-python-dateutil==2.7.5
+twarc==2.8.2
+python-dateutil==2.8.2
 
 # Master support Py3, but no release. This should be in sfm-utils setup.py once released.
 git+https://github.com/Supervisor/supervisor

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,5 +1,5 @@
-twarc==2.11.1
-twarc-csv==0.5.2
+twarc==2.12.0
+twarc-csv==0.6.0
 python-dateutil==2.8.2
 
 # Master support Py3, but no release. This should be in sfm-utils setup.py once released.

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,6 @@
-twarc==2.8.2
+twarc==2.11.1
+twarc-csv==0.5.2
 python-dateutil==2.8.2
-#twarc-csv==0.5.2
 
 # Master support Py3, but no release. This should be in sfm-utils setup.py once released.
 git+https://github.com/Supervisor/supervisor

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,9 +10,11 @@ except ImportError:
     TWITTER_CONSUMER_SECRET = os.environ.get("TWITTER_CONSUMER_SECRET", "fake")
     TWITTER_ACCESS_TOKEN = os.environ.get("TWITTER_ACCESS_TOKEN", "fake")
     TWITTER_ACCESS_TOKEN_SECRET = os.environ.get("TWITTER_ACCESS_TOKEN_SECRET", "fake")
+    TWITTER_BEARER_TOKEN = os.environ.get("TWITTER_BEARER_TOKEN", "fake")
 
-test_config_available = True if TWITTER_CONSUMER_KEY != "fake" and TWITTER_CONSUMER_SECRET != "fake" \
-                                and TWITTER_ACCESS_TOKEN != "fake" and TWITTER_ACCESS_TOKEN_SECRET != "fake" else False
+test_config_available = (TWITTER_CONSUMER_KEY != "fake" and TWITTER_CONSUMER_SECRET != "fake"
+                         and TWITTER_ACCESS_TOKEN != "fake" and TWITTER_ACCESS_TOKEN_SECRET != "fake") \
+                         or TWITTER_BEARER_TOKEN != "fake"
 
 mq_port_available = True
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/tests/test_twitter_harvester.py
+++ b/tests/test_twitter_harvester.py
@@ -3,7 +3,7 @@ import tests
 import unittest
 from mock import MagicMock, patch, call
 from twitter_harvester import TwitterHarvester
-from twarc import Twarc
+from twarc import Twarc, Twarc2
 import threading
 import shutil
 import tempfile
@@ -17,7 +17,7 @@ from sfmutils.state_store import DictHarvestStateStore
 from sfmutils.harvester import HarvestResult, EXCHANGE, CODE_TOKEN_NOT_FOUND, STATUS_RUNNING, \
     STATUS_SUCCESS, STATUS_STOPPING
 from sfmutils.warc_iter import IterItem
-from twitter_rest_warc_iter import TwitterRestWarcIter
+from twitter_rest_warc_iter import TwitterRestWarcIter, TwitterRestWarcIter2
 from requests.exceptions import HTTPError
 
 base_search_message = {
@@ -35,6 +35,30 @@ base_search_message = {
         "consumer_secret": tests.TWITTER_CONSUMER_SECRET,
         "access_token": tests.TWITTER_ACCESS_TOKEN,
         "access_token_secret": tests.TWITTER_ACCESS_TOKEN_SECRET
+    },
+    "options": {
+        "tweets": True
+    },
+    "collection_set": {
+        "id": "test_collection_set"
+    }
+}
+
+base_search_message_2 = {
+    "id": "test:1",
+    "type": "twitter_search_2",
+    "path": "/collections/test_collection_set/collection_id",
+    "seeds": [
+        {
+            "token": "gelman"
+        }
+    ],
+    "credentials": {
+        "consumer_key": tests.TWITTER_CONSUMER_KEY,
+        "consumer_secret": tests.TWITTER_CONSUMER_SECRET,
+        "access_token": tests.TWITTER_ACCESS_TOKEN,
+        "access_token_secret": tests.TWITTER_ACCESS_TOKEN_SECRET,
+        "bearer_token": tests.TWITTER_BEARER_TOKEN
     },
     "options": {
         "tweets": True
@@ -67,6 +91,36 @@ base_timeline_message = {
         "consumer_secret": tests.TWITTER_CONSUMER_SECRET,
         "access_token": tests.TWITTER_ACCESS_TOKEN,
         "access_token_secret": tests.TWITTER_ACCESS_TOKEN_SECRET
+    },
+    "collection_set": {
+        "id": "test_collection_set"
+    }
+}
+
+base_timeline_message_2 = {
+    "id": "test:1",
+    "type": "twitter_user_timeline_2",
+    "path": "/collections/test_collection_set/collection_id",
+    "seeds": [
+        {
+            "id": "seed_id1",
+            "uid": "28101965"
+        },
+        {
+            "id": "seed_id2",
+            "token": "gelmanlibrary"
+        }
+
+    ],
+    "options": {
+        "tweets": True
+    },
+    "credentials": {
+        "consumer_key": tests.TWITTER_CONSUMER_KEY,
+        "consumer_secret": tests.TWITTER_CONSUMER_SECRET,
+        "access_token": tests.TWITTER_ACCESS_TOKEN,
+        "access_token_secret": tests.TWITTER_ACCESS_TOKEN_SECRET,
+        "bearer_token": tests.TWITTER_BEARER_TOKEN
     },
     "collection_set": {
         "id": "test_collection_set"
@@ -401,6 +455,319 @@ class TestTwitterHarvester(tests.TestCase):
         iter_class.assert_called_once_with("test.warc.gz")
         # State updated
         self.assertEqual(660065173563158500,
+                         self.harvester.state_store.get_state("twitter_harvester", "timeline.481186914.since_id"))
+
+
+class TestTwitterHarvester2(tests.TestCase):
+    def setUp(self):
+        self.working_path = tempfile.mkdtemp()
+
+        self.harvester = TwitterHarvester(self.working_path)
+        self.harvester.state_store = DictHarvestStateStore()
+        self.harvester.message = base_search_message_2
+        self.harvester.result = HarvestResult()
+        self.harvester.stop_harvest_seeds_event = threading.Event()
+
+    def tearDown(self):
+        if os.path.exists(self.working_path):
+            shutil.rmtree(self.working_path)
+
+    @patch("twitter_harvester.Twarc2", autospec=True)
+    def test_search_2(self, mock_twarc_class):
+        mock_twarc = MagicMock(spec=Twarc2)
+        mock_twarc.search_recent.side_effect = [join_tweets(tweet1_2, tweet2_2), ()]
+        # Return mock_twarc when instantiating a twarc.
+        mock_twarc_class.side_effect = [mock_twarc]
+
+        self.harvester.message = base_search_message_2
+        self.harvester.harvest_seeds()
+
+        mock_twarc_class.assert_called_once_with(tests.TWITTER_CONSUMER_KEY, tests.TWITTER_CONSUMER_SECRET,
+                                                 tests.TWITTER_ACCESS_TOKEN, tests.TWITTER_ACCESS_TOKEN_SECRET,
+                                                 tests.TWITTER_BEARER_TOKEN, connection_errors=5, metadata=True)
+        self.assertEqual([call("gelman", since_id=None)], mock_twarc.search_recent.mock_calls)
+        self.assertDictEqual({"tweets": 2}, self.harvester.result.harvest_counter)
+
+    @patch("twitter_harvester.Twarc2", autospec=True)
+    def test_academic_search(self, mock_twarc_class):
+        # Backward-compatibility for geocode parameters v2: "point_radius".
+        # Only available for Twitter's Academic Research product track search.
+        mock_twarc = MagicMock(spec=Twarc2)
+        mock_twarc.search_all.side_effect = [join_tweets(tweet1_2, tweet2_2), ()]
+        # Return mock_twarc when instantiating a twarc.
+        mock_twarc_class.side_effect = [mock_twarc]
+
+        search_message = copy.deepcopy(base_search_message_2)
+        search_message["seeds"][0]["token"] = {
+            "query": "gelman",
+            "geocode": "38.899434,-77.036449,25mi"
+        }
+        search_message["options"]["twitter_academic_research"] = True
+
+        self.harvester.message = search_message
+        self.harvester.harvest_seeds()
+
+        mock_twarc_class.assert_called_once_with(tests.TWITTER_CONSUMER_KEY, tests.TWITTER_CONSUMER_SECRET,
+                                                 tests.TWITTER_ACCESS_TOKEN, tests.TWITTER_ACCESS_TOKEN_SECRET,
+                                                 tests.TWITTER_BEARER_TOKEN, connection_errors=5, metadata=True)
+        self.assertEqual([call("gelman point_radius:[38.899434 -77.036449 25mi]", since_id=None)],
+                         mock_twarc.search_all.mock_calls)
+        self.assertDictEqual({"tweets": 2}, self.harvester.result.harvest_counter)
+
+    @patch("twitter_harvester.Twarc2", autospec=True)
+    def test_user_timeline_2(self, mock_twarc_class):
+        mock_twarc = MagicMock(spec=Twarc2)
+        # Expecting 2 user timelines. First returns 2 tweets. Second returns none.
+        mock_twarc.timeline.side_effect = [join_tweets(tweet1_2, tweet2_2), ()]
+        # Expecting 2 calls to get for user lookup
+        mock_response1 = MagicMock()
+        mock_response1.status_code = 200
+        mock_response1.json.return_value = {'data': {'protected': False, 'username': 'gwtweets', 'id': '28101965', 'name': 'GW Tweets'}}
+        mock_response2 = MagicMock()
+        mock_response2.status_code = 200
+        mock_response2.json.return_value = {'data': {"id": "9710852", "protected": False, 'username': 'justin_littman', 'name': 'Justin Littman'}}
+        mock_twarc.get.side_effect = [mock_response1, mock_response2]
+        # Return mock_twarc when instantiating a twarc.
+        mock_twarc_class.side_effect = [mock_twarc]
+
+        self.harvester.message = base_timeline_message_2
+        self.harvester.harvest_seeds()
+
+        mock_twarc_class.assert_called_once_with(tests.TWITTER_CONSUMER_KEY, tests.TWITTER_CONSUMER_SECRET,
+                                                 tests.TWITTER_ACCESS_TOKEN, tests.TWITTER_ACCESS_TOKEN_SECRET,
+                                                 tests.TWITTER_BEARER_TOKEN, connection_errors=5, metadata=True)
+        self.assertEqual([call(user="28101965", since_id=None), call(user="9710852", since_id=None)],
+                         mock_twarc.timeline.mock_calls)
+        self.assertDictEqual({"tweets": 2}, self.harvester.result.harvest_counter)
+
+    @patch("twitter_harvester.Twarc2", autospec=True)
+    def test_incremental_user_timeline_2(self, twarc_class):
+        message = copy.deepcopy(base_timeline_message_2)
+        message["options"]["incremental"] = True
+
+        mock_twarc = MagicMock(spec=Twarc2)
+        # Expecting 2 timelines. First returns 1 tweets. Second returns none.
+        mock_twarc.timeline.side_effect = [tweet2_2, ()]
+        # Expecting 2 calls to get for user lookup
+        mock_response1 = MagicMock()
+        mock_response1.status_code = 200
+        mock_response1.json.return_value = {'data': {'protected': False, 'username': 'gwtweets', 'id': '28101965', 'name': 'GW Tweets'}}
+        mock_response2 = MagicMock()
+        mock_response2.status_code = 200
+        mock_response2.json.return_value = {'data': {"id": "9710852", "protected": False, 'username': 'justin_littman', 'name': 'Justin Littman'}}
+        mock_twarc.get.side_effect = [mock_response1, mock_response2]
+        # Return mock_twarc when instantiating a twarc.
+        twarc_class.side_effect = [mock_twarc]
+
+        self.harvester.message = message
+        self.harvester.state_store.set_state("twitter_harvester", "timeline.28101965.since_id", 605726286741434400)
+        self.harvester.harvest_seeds()
+
+        twarc_class.assert_called_once_with(tests.TWITTER_CONSUMER_KEY, tests.TWITTER_CONSUMER_SECRET,
+                                            tests.TWITTER_ACCESS_TOKEN, tests.TWITTER_ACCESS_TOKEN_SECRET,
+                                            tests.TWITTER_BEARER_TOKEN, connection_errors=5, metadata=True)
+        self.assertEqual(
+            [call(user="28101965", since_id=605726286741434400),
+             call(user="9710852", since_id=None)], mock_twarc.timeline.mock_calls)
+        self.assertDictEqual({"tweets": 1}, self.harvester.result.harvest_counter)
+
+    @patch("twitter_harvester.Twarc2", autospec=True) 
+    def test_user_timeline_with_missing_users_2(self, mock_twarc_class):
+        mock_twarc = MagicMock(spec=Twarc2)
+        # Expecting 2 calls to user_lookup, both which return nothing
+        mock_twarc.user_lookup.side_effect = [[], []]
+        # Return mock_twarc when instantiating a twarc.
+        mock_twarc_class.side_effect = [mock_twarc]
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        response = {'errors': [{'value': 'missing1', 'detail': 'Could not find user with usernames: [missing1].',
+                                'title': 'Not Found Error',
+                                'resource_type': 'user', 'parameter': 'usernames', 'resource_id': 'missing1',
+                                'type': 'https://api.twitter.com/2/problems/resource-not-found'}]}
+        mock_response.json.return_value = response
+        mock_twarc.get.return_value = mock_response
+
+        message = copy.deepcopy(base_timeline_message_2)
+        message["seeds"] = [
+            {
+                "id": "seed_id1",
+                "token": "missing1"
+            },
+            {
+                "id": "seed_id2",
+                "token": "missing2"
+            }
+
+        ]
+        self.harvester.message = message
+        self.harvester.harvest_seeds()
+
+        mock_twarc_class.assert_called_once_with(tests.TWITTER_CONSUMER_KEY, tests.TWITTER_CONSUMER_SECRET,
+                                                 tests.TWITTER_ACCESS_TOKEN, tests.TWITTER_ACCESS_TOKEN_SECRET,
+                                                 tests.TWITTER_BEARER_TOKEN, connection_errors=5, metadata=True)
+
+        self.assertEqual(
+            [call('https://api.twitter.com/2/users/by/username/missing1?user.fields=protected'),
+             call().json(),
+             call('https://api.twitter.com/2/users/by/username/missing2?user.fields=protected'),
+             call().json()],
+             mock_twarc.get.mock_calls)
+        self.assertEqual(2, len(self.harvester.result.warnings))
+        self.assertEqual(CODE_TOKEN_NOT_FOUND, self.harvester.result.warnings[0].code)
+        self.assertEqual("seed_id1", self.harvester.result.warnings[0].extras["seed_id"])
+    
+    def mock_user_lookup(self, response, response_code=200):
+        mock_twarc = MagicMock(spec=Twarc2)
+        mock_response = MagicMock()
+        mock_response.status_code = response_code
+        mock_response.json.return_value = response
+        mock_twarc.get.return_value = mock_response
+        if response_code != 200:
+            mock_twarc.get.side_effect = HTTPError(response=mock_response)
+        return mock_twarc
+
+    def mock_user_lookup_verify(self, mockobj, *args, **kwargs):
+        mockobj.get.assert_called_once_with(*args, **kwargs)
+
+    def test_lookup_screen_name_2(self):
+        response = {'data': {'protected': False, 'username': 'justin_littman', 'id': '481186914', 'name': 'Justin Littman'}}
+
+        self.harvester.twarc = mock_twarc = self.mock_user_lookup(response)
+
+        self.assertEqual(('OK', response['data']),
+                         self.harvester._lookup_user_2(id="481186914", id_type="user_id"))
+    
+    def test_lookup_missing_screen_name_2(self):
+        response = {'errors': [{'value': '481186914', 'detail': 'Could not find user with ids: [481186914].',
+                                'title': 'Not Found Error', 'resource_type': 'user', 'parameter': 'ids',
+                                'resource_id': '481186914', 'type': 'https://api.twitter.com/2/problems/resource-not-found'}]}
+
+        self.harvester.twarc = mock_twarc = self.mock_user_lookup(response)
+
+        self.assertEqual(('not_found', None), self.harvester._lookup_user_2(id="481186914", id_type="user_id"))
+
+        self.mock_user_lookup_verify(mock_twarc,
+                                     'https://api.twitter.com/2/users/481186914?user.fields=protected')
+
+    def test_lookup_user_id_2(self):
+        response = {'data': {'protected': False, 'username': 'justin_littman', 'id': '481186914', 'name': 'Justin Littman'}}
+        self.harvester.twarc = mock_twarc = self.mock_user_lookup(response)
+
+        self.assertEqual(('OK', response['data']),
+                         self.harvester._lookup_user_2(id="justin_littman", id_type="screen_name"))
+
+        self.mock_user_lookup_verify(mock_twarc,
+                                     'https://api.twitter.com/2/users/by/username/justin_littman?user.fields=protected')
+
+    def test_lookup_missing_user_id_2(self):
+        response = {'errors': [{'value': 'justin_littman', 'detail': 'Could not find user with usernames: [justin_littman].', 'title': 'Not Found Error',
+                                'resource_type': 'user', 'parameter': 'usernames', 'resource_id': 'justin_littman',
+                                'type': 'https://api.twitter.com/2/problems/resource-not-found'}]}
+
+        self.harvester.twarc = mock_twarc = self.mock_user_lookup(response)
+
+        self.assertEqual(('not_found', None), self.harvester._lookup_user_2(id="justin_littman", id_type="screen_name"))
+
+        self.mock_user_lookup_verify(mock_twarc,
+                                     'https://api.twitter.com/2/users/by/username/justin_littman?user.fields=protected')
+
+    def test_lookup_invalid_user_id_2(self):
+        self.harvester.twarc = mock_twarc = self.mock_user_lookup(None, 400)
+
+        self.assertEqual(('not_found', None), self.harvester._lookup_user_2(id="123456789012345678901234567890", id_type="user_id"))
+
+        self.mock_user_lookup_verify(mock_twarc,
+                                     'https://api.twitter.com/2/users/123456789012345678901234567890?user.fields=protected')
+
+    def test_lookup_suspended_screen_name_2(self):
+        response = {'errors': [{'parameter': 'ids', 'resource_id': '481186914', 'value': '481186914',
+                                'detail': 'User has been suspended: [481186914].', 'title': 'Forbidden',
+                                'resource_type': 'user', 'type': 'https://api.twitter.com/2/problems/resource-not-found'}]}
+
+        self.harvester.twarc = mock_twarc = self.mock_user_lookup(response)
+
+        self.assertEqual(('suspended', None), self.harvester._lookup_user_2(id="481186914", id_type="user_id"))
+
+        self.mock_user_lookup_verify(mock_twarc,
+                                     'https://api.twitter.com/2/users/481186914?user.fields=protected')
+
+    @staticmethod
+    def _iter_items(items):
+        # This is useful for mocking out a warc iter
+        iter_items = []
+        for item in items:
+            iter_items.append(IterItem(None, None, None, None, item))
+        return iter_items
+    
+    @patch("twitter_harvester.TwitterRestWarcIter2", autospec=True)
+    def test_process_search_2(self, iter_class):
+        mock_iter = MagicMock(spec=TwitterRestWarcIter2)
+        mock_iter.__iter__.side_effect = [self._iter_items(tweet2_2['data']).__iter__()]
+        # Return mock_iter when instantiating a TwitterRestWarcIter2.
+        iter_class.side_effect = [mock_iter]
+
+        self.harvester.message = base_search_message_2
+        self.harvester.process_warc("test.warc.gz")
+
+        self.assertDictEqual({"tweets": 1}, self.harvester.result.stats_summary())
+        iter_class.assert_called_once_with("test.warc.gz")
+        # State updated
+        self.assertEqual(None, self.harvester.state_store.get_state("twitter_harvester", "gelman.since_id"))
+   
+    @patch("twitter_harvester.TwitterRestWarcIter2", autospec=True)
+    def test_process_search_incremental_2(self, iter_class):
+        message = copy.deepcopy(base_search_message_2)
+        message["options"]["incremental"] = True
+
+        mock_iter = MagicMock(spec=TwitterRestWarcIter2)
+        mock_iter.__iter__.side_effect = [self._iter_items(tweet2_2['data']).__iter__()]
+        # Return mock_iter when instantiating a TwitterRestWarcIter2.
+        iter_class.side_effect = [mock_iter]
+
+        self.harvester.state_store.set_state("twitter_harvester", "gelman.since_id", 605726286741434400)
+        self.harvester.message = message
+        self.harvester.process_warc("test.warc.gz")
+
+        self.assertDictEqual({"tweets": 1}, self.harvester.result.stats_summary())
+        iter_class.assert_called_once_with("test.warc.gz")
+        # State updated
+        self.assertEqual(660065173563158529,
+                         self.harvester.state_store.get_state("twitter_harvester", "gelman.since_id"))
+
+    @patch("twitter_harvester.TwitterRestWarcIter2", autospec=True)
+    def test_process_user_timeline_2(self, iter_class):
+        mock_iter = MagicMock(spec=TwitterRestWarcIter)
+        mock_iter.__iter__.side_effect = [self._iter_items(join_tweets(tweet1_2, tweet2_2)['data']).__iter__()]
+        # Return mock_iter when instantiating a TwitterRestWarcIter.
+        iter_class.side_effect = [mock_iter]
+
+        self.harvester.message = base_timeline_message_2
+        self.harvester.process_warc("test.warc.gz")
+
+        self.assertDictEqual({"tweets": 2}, self.harvester.result.stats_summary())
+        iter_class.assert_called_once_with("test.warc.gz")
+        # # Nothing added to state
+        self.assertEqual(0, len(self.harvester.state_store.state))
+
+    @patch("twitter_harvester.TwitterRestWarcIter2", autospec=True)
+    def test_process_incremental_user_timeline_2(self, iter_class):
+        message = copy.deepcopy(base_timeline_message_2)
+        message["options"]["incremental"] = True
+
+        mock_iter = MagicMock(spec=TwitterRestWarcIter2)
+        mock_iter.__iter__.side_effect = [self._iter_items(tweet2_2['data']).__iter__()]
+        # Return mock_iter when instantiating a TwitterRestWarcIter2.
+        iter_class.side_effect = [mock_iter]
+
+        self.harvester.message = message
+        self.harvester.state_store.set_state("twitter_harvester", "timeline.481186914.since_id", 605726286741434400)
+        self.harvester.process_warc("test.warc.gz")
+
+        self.assertDictEqual({"tweets": 1}, self.harvester.result.stats_summary())
+        iter_class.assert_called_once_with("test.warc.gz")
+        # State updated
+        self.assertEqual(660065173563158529,
                          self.harvester.state_store.get_state("twitter_harvester", "timeline.481186914.since_id"))
 
 

--- a/tests/test_twitter_rest_exporter.py
+++ b/tests/test_twitter_rest_exporter.py
@@ -4,13 +4,16 @@
 from __future__ import absolute_import
 import tests
 from tests.tweets import tweet2
-from twitter_rest_exporter import TwitterRestStatusTable
+#from twitter_rest_exporter import TwitterRestStatusTable
+from twitter_rest_exporter import BaseTwitterStatusTable, BaseTwitterTwoStatusTable, create_twitter_status_table_class
+from twitter_rest_warc_iter import TwitterRestWarcIter2
 from datetime import datetime
 
 
 class TestTwitterStatusTable(tests.TestCase):
     def test_row(self):
-        table = TwitterRestStatusTable(None, None, None, None, None, None)
+        table_cls = create_twitter_status_table_class(BaseTwitterStatusTable)
+        table = table_cls(None, None, None, None, None, None)
         row = table._row(tweet2)
         self.assertEqual("660065173563158529", row[0])
         self.assertEqual("https://twitter.com/justin_littman/status/660065173563158529", row[1])
@@ -19,3 +22,17 @@ class TestTwitterStatusTable(tests.TestCase):
         self.assertEqual("My new blog post on techniques for harvesting social media to WARCs: https://t.co/OHZki6pXEe",
                          row[5])
         self.assertEqual("original", row[6])
+'''
+class TestTwitterStatusTable2(tests.TestCase):
+    def test_row(self):
+        table_cls = create_twitter_status_table_class(BaseTwitterTwoStatusTable, TwitterRestWarcIter2)
+        table = table_cls(None, None, None, None, None, None)
+        row = table._row(tweet2)
+        self.assertEqual("660065173563158529", row[0])
+        self.assertEqual("https://twitter.com/justin_littman/status/660065173563158529", row[1])
+        self.assertIsInstance(row[3], datetime)
+        self.assertEqual("justin_littman", row[4])
+        self.assertEqual("My new blog post on techniques for harvesting social media to WARCs: https://t.co/OHZki6pXEe",
+                         row[5])
+        self.assertEqual("original", row[6])
+'''

--- a/tests/tweets.py
+++ b/tests/tweets.py
@@ -1,5 +1,29 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import copy
+
+def join_tweets(*tweets):
+    res = {}
+    for tweet in tweets:
+        for k in ('data', 'errors', 'includes', 'meta'):
+            if k not in tweet:
+                continue
+            c = copy.deepcopy(tweet[k])
+            if k not in res:
+                res[k] = c
+            elif k == 'meta':
+                pass
+            elif k == 'includes':
+                for kk in c:
+                    if kk not in res['includes']:
+                        res[k][kk] = c[kk]
+                    else:
+                        for i in c[kk]:
+                            res[k][kk].append(i)
+            else:
+                for i in c:
+                    res[k].append(i)
+    return res
 
 tweet1 = {
     "created_at": "Tue Jun 02 13:22:55 +0000 2015",
@@ -1452,4 +1476,603 @@ tweet8 = {
   "favorited": False,
   "retweeted": False,
   "lang": "en"
+}
+
+tweet1_2 = {
+    'data': [
+        {
+            'lang': 'en',
+            'created_at': '2015-06-02T13:22:55.000Z',
+            'id': '605726286741434368',
+            'source': 'Twitter Web Client',
+            'author_id': '481186914',
+            'reply_settings': 'everyone',
+            'geo': {
+                'place_id': '01fbe706f872cb32'
+            },
+            'text': 'At LC for @archemail today:  Thinking about overlap between email archiving, web archiving, and social media archiving.',
+            'public_metrics': {
+                'retweet_count': 0,
+                'reply_count': 0,
+                'like_count': 0,
+                'quote_count': 0
+            },
+            'possibly_sensitive': False,
+            'conversation_id': '605726286741434368'
+        }
+    ],
+    'includes': {
+        'users': [
+            {
+                'public_metrics': {
+                    'followers_count': 796,
+                    'following_count': 72,
+                    'tweet_count': 2254,
+                    'listed_count': 30
+                },
+                'entities': {
+                    'description': {
+                        'mentions': [
+                            {
+                                'start': 25,
+                                'end': 36,
+                                'username': 'DigitalLib'
+                            },
+                            {
+                                'start': 49,
+                                'end': 63,
+                                'username': 'gelmanlibrary'
+                            },
+                            {
+                                'start': 66,
+                                'end': 82,
+                                'username': 'librarycongress'
+                            }
+                        ]
+                    }
+                },
+                'username': 'justin_littman',
+                'name': 'Justin Littman',
+                'id': '481186914',
+                'verified': False,
+                'location': 'Fairfax, VA',
+                'url': '',
+                'description': 'Software dev at Stanford @DigitalLib. Previously @gelmanlibrary & @librarycongress.',
+                'protected': False,
+                'profile_image_url': 'https://pbs.twimg.com/profile_images/496478011533713408/GjecBUNj_normal.jpeg',
+                'created_at': '2012-02-02T12:19:18.000Z'
+            }
+        ],
+        'places': [
+            {
+                'geo': {
+                    'type': 'Feature',
+                    'bbox': [-77.119401, 38.801826, -76.909396, 38.9953797],
+                    'properties': {}
+                },
+                'name': 'Washington',
+                'full_name': 'Washington, DC',
+                'place_type': 'city',
+                'id': '01fbe706f872cb32',
+                'country_code': 'US',
+                'country': 'United States'
+            }
+        ]
+    }
+}
+
+# tweet2 has a url
+tweet2_2 = {
+    'data': [
+        {
+            'entities': {
+                'urls': [
+                    {
+                        'start': 69,
+                        'end': 92,
+                        'url': 'https://t.co/OHZki6pXEe',
+                        'expanded_url': 'http://bit.ly/1ipwd0B',
+                        'display_url': 'bit.ly/1ipwd0B',
+                        'status': 200,
+                        'unwound_url': 'https://library.gwu.edu/collecting-social-media-data'
+                    }
+                ]
+            },
+            'reply_settings': 'everyone',
+            'public_metrics': {
+                'retweet_count': 9,
+                'reply_count': 0,
+                'like_count': 9,
+                'quote_count': 0
+            },
+            'conversation_id': '660065173563158529',
+            'source': 'Twitter Web Client',
+            'author_id': '481186914',
+            'possibly_sensitive': False,
+            'created_at': '2015-10-30T12:06:15.000Z',
+            'text': 'My new blog post on techniques for harvesting social media to WARCs: https://t.co/OHZki6pXEe',
+            'lang': 'en',
+            'id': '660065173563158529'
+        }
+    ],
+    'includes': {
+        'users': [
+            {
+                'location': 'Fairfax, VA',
+                'url': '',
+                'username': 'justin_littman',
+                'entities': {
+                    'description': {
+                        'mentions': [
+                            {
+                                'start': 25,
+                                'end': 36,
+                                'username': 'DigitalLib'
+                            },
+                            {
+                                'start': 49,
+                                'end': 63,
+                                'username': 'gelmanlibrary'
+                            },
+                            {
+                                'start': 66,
+                                'end': 82,
+                                'username': 'librarycongress'
+                            }
+                        ]
+                    }
+                },
+                'name': 'Justin Littman',
+                'id': '481186914',
+                'created_at': '2012-02-02T12:19:18.000Z',
+                'verified': False,
+                'description': 'Software dev at Stanford @DigitalLib. Previously @gelmanlibrary & @librarycongress.',
+                'protected': False,
+                'public_metrics': {
+                    'followers_count': 796,
+                    'following_count': 72,
+                    'tweet_count': 2254,
+                    'listed_count': 30
+                },
+                'profile_image_url': 'https://pbs.twimg.com/profile_images/496478011533713408/GjecBUNj_normal.jpeg'
+            }
+        ]
+    }
+}
+
+# tweet3 has "attachments" (API v1: "extended_entities") 
+tweet3_2 = {
+    'data': [
+        {
+            'id': '727894186415013888',
+            'lang': 'en',
+            'attachments': {
+                'media_keys': [
+                    '16_727894166961831936']
+            },
+            'created_at': '2016-05-04T16:14:32.000Z',
+            'source': 'Twitter Web Client',
+            'author_id': '2875189485',
+            'public_metrics': {
+                'retweet_count': 0,
+                'reply_count': 0,
+                'like_count': 0,
+                'quote_count': 0
+            },
+            'text': 'Test tweet 9. Tweet with a GIF. https://t.co/x6AYFg3REg',
+            'reply_settings': 'everyone',
+            'conversation_id': '727894186415013888',
+            'possibly_sensitive': False,
+            'entities': {
+                'urls': [
+                    {
+                        'start': 32,
+                        'end': 55,
+                        'url': 'https://t.co/x6AYFg3REg',
+                        'expanded_url': 'https://twitter.com/jlittman_dev/status/727894186415013888/photo/1',
+                        'display_url': 'pic.twitter.com/x6AYFg3REg'
+                    }
+                ]
+            }
+        }
+    ],
+    'includes': {
+        'media': [
+            {
+                'preview_image_url': 'https://pbs.twimg.com/tweet_video_thumb/Chn_42fWwAASuva.jpg',
+                'media_key': '16_727894166961831936',
+                'height': 230,
+                'type': 'animated_gif',
+                'width': 300
+            }
+        ],
+        'users': [
+            {
+                'profile_image_url': 'https://abs.twimg.com/sticky/default_profile_images/default_profile_normal.png',
+                'verified': False,
+                'id': '2875189485',
+                'name': 'Justin Littman dev',
+                'url': '',
+                'description': '',
+                'public_metrics': {
+                    'followers_count': 0,
+                    'following_count': 0,
+                    'tweet_count': 29,
+                    'listed_count': 2
+                },
+                'protected': False,
+                'username': 'jlittman_dev',
+                'created_at': '2014-11-13T15:49:55.000Z'
+            }
+        ]
+    }
+}
+
+# tweet4 has "referenced_tweets" (API v1: "quoted_status")
+tweet4_2 = {
+    'data': [
+        {
+            'entities': {
+                'urls': [
+                    {
+                        'start': 18,
+                        'end': 41,
+                        'url': 'https://t.co/tBu6RRJoKr',
+                        'expanded_url': 'https://twitter.com/justin_littman/status/503873833213104128',
+                        'display_url': 'twitter.com/justin_littman…'
+                    }
+                ]
+            },
+            'lang': 'en',
+            'created_at': '2016-05-04T18:39:55.000Z',
+            'referenced_tweets': [
+                {
+                    'type': 'quoted',
+                    'id': '503873833213104128'
+                }
+            ],
+            'id': '727930772691292161',
+            'source': 'Twitter Web Client',
+            'author_id': '2875189485',
+            'reply_settings': 'everyone',
+            'text': 'Test 10. Retweet. https://t.co/tBu6RRJoKr',
+            'public_metrics': {
+                'retweet_count': 0,
+                'reply_count': 0,
+                'like_count': 0,
+                'quote_count': 0
+            },
+            'possibly_sensitive': False,
+            'conversation_id': '727930772691292161'
+        }
+    ],
+    'includes': {
+        'users': [
+            {
+                'public_metrics': {
+                    'followers_count': 0,
+                    'following_count': 0,
+                    'tweet_count': 29,
+                    'listed_count': 2
+                },
+                'username': 'jlittman_dev',
+                'name': 'Justin Littman dev',
+                'id': '2875189485',
+                'verified': False,
+                'url': '',
+                'description': '',
+                'protected': False,
+                'profile_image_url': 'https://abs.twimg.com/sticky/default_profile_images/default_profile_normal.png',
+                'created_at': '2014-11-13T15:49:55.000Z'
+            },
+            {
+                'public_metrics': {
+                    'followers_count': 796,
+                    'following_count': 72,
+                    'tweet_count': 2254,
+                    'listed_count': 30
+                },
+                'entities': {
+                    'description': {
+                        'mentions': [
+                            {
+                                'start': 25,
+                                'end': 36,
+                                'username': 'DigitalLib'
+                            },
+                            {
+                                'start': 49,
+                                'end': 63,
+                                'username': 'gelmanlibrary'
+                            },
+                            {
+                                'start': 66,
+                                'end': 82,
+                                'username': 'librarycongress'
+                            }
+                        ]
+                    }
+                },
+                'username': 'justin_littman',
+                'name': 'Justin Littman',
+                'id': '481186914',
+                'verified': False,
+                'location': 'Fairfax, VA',
+                'url': '',
+                'description': 'Software dev at Stanford @DigitalLib. Previously @gelmanlibrary & @librarycongress.',
+                'protected': False,
+                'profile_image_url': 'https://pbs.twimg.com/profile_images/496478011533713408/GjecBUNj_normal.jpeg',
+                'created_at': '2012-02-02T12:19:18.000Z'
+            }
+        ],
+        'tweets': [
+            {
+                'entities': {
+                    'urls': [
+                        {
+                            'start': 42,
+                            'end': 64,
+                            'url': 'http://t.co/Gz5ybAD6os',
+                            'expanded_url': 'https://twitter.com/justin_littman/status/503873833213104128/photo/1',
+                            'display_url': 'pic.twitter.com/Gz5ybAD6os'
+                        }
+                    ],
+                    'annotations': [
+                        {
+                            'start': 13,
+                            'end': 26,
+                            'probability': 0.7965,
+                            'type': 'Place',
+                            'normalized_text': 'Gelman Library'
+                        }
+                    ]
+                },
+                'lang': 'en',
+                'created_at': '2014-08-25T11:57:38.000Z',
+                'id': '503873833213104128',
+                'source': 'Twitter for Android',
+                'author_id': '481186914',
+                'reply_settings': 'everyone',
+                'attachments': {
+                    'media_keys': [
+                        '3_503873819560665088']
+                },
+                'text': 'First day at Gelman Library. First tweet. http://t.co/Gz5ybAD6os',
+                'public_metrics': {
+                    'retweet_count': 0,
+                    'reply_count': 4,
+                    'like_count': 6,
+                    'quote_count': 0
+                },
+                'possibly_sensitive': False,
+                'conversation_id': '503873833213104128'
+            }
+        ]
+    }
+}
+
+# tweet 8 is a quote tweet nested in a retweet
+tweet8_2 = {
+    'data': [
+        {
+            'reply_settings': 'everyone',
+            'referenced_tweets': [
+                {
+                    'type': 'retweeted',
+                    'id': '918436293247406080'
+                }
+            ],
+            'text': 'RT @ClimateCentral: Wildfire season in the American West is now two and a half months longer than it was 40 years ago. Our wildfire report…',
+            'id': '918735887264972800',
+            'entities': {
+                'annotations': [
+                    {
+                        'start': 43,
+                        'end': 55,
+                        'probability': 0.4504,
+                        'type': 'Place',
+                        'normalized_text': 'American West'
+                    }
+                ],
+                'mentions': [
+                    {
+                        'start': 3,
+                        'end': 18,
+                        'username': 'ClimateCentral',
+                        'id': '15463610'
+                    }
+                ]
+            },
+            'possibly_sensitive': False,
+            'conversation_id': '918735887264972800',
+            'public_metrics': {
+                'retweet_count': 168,
+                'reply_count': 0,
+                'like_count': 0,
+                'quote_count': 0
+            },
+            'lang': 'en',
+            'author_id': '1074184813',
+            'source': 'Twitter for iPhone',
+            'created_at': '2017-10-13T07:11:19.000Z'
+        }
+    ],
+    'includes': {
+        'users': [
+            {
+                'description': '#VWars 🧛🏻\u200d♂️#LutherSwann #Damon #TVD #Delena #IanSomerhalder #NikkiReed #SOMEREED #Bodhi👶🏻 ❤️#ISF 🐶🐱#Yoga🧘🏻\u200d♀️#BeautifulHumans #HarryPotter🦉⚡️🏆',
+                'name': 'DamonSmolderhalder😈',
+                'entities': {
+                    'description': {
+                        'hashtags': [
+                            {
+                                'start': 0,
+                                'end': 6,
+                                'tag': 'VWars'
+                            },
+                            {
+                                'start': 12,
+                                'end': 24,
+                                'tag': 'LutherSwann'
+                            },
+                            {
+                                'start': 25,
+                                'end': 31,
+                                'tag': 'Damon'
+                            },
+                            {
+                                'start': 32,
+                                'end': 36,
+                                'tag': 'TVD'
+                            },
+                            {
+                                'start': 37,
+                                'end': 44,
+                                'tag': 'Delena'
+                            },
+                            {
+                                'start': 45,
+                                'end': 60,
+                                'tag': 'IanSomerhalder'
+                            },
+                            {
+                                'start': 61,
+                                'end': 71,
+                                'tag': 'NikkiReed'
+                            },
+                            {
+                                'start': 72,
+                                'end': 81,
+                                'tag': 'SOMEREED'
+                            },
+                            {
+                                'start': 82,
+                                'end': 88,
+                                'tag': 'Bodhi'
+                            },
+                            {
+                                'start': 93,
+                                'end': 97,
+                                'tag': 'ISF'
+                            },
+                            {
+                                'start': 100,
+                                'end': 105,
+                                'tag': 'Yoga'
+                            },
+                            {
+                                'start': 110,
+                                'end': 126,
+                                'tag': 'BeautifulHumans'
+                            },
+                            {
+                                'start': 127,
+                                'end': 139,
+                                'tag': 'HarryPotter'
+                            }
+                        ]
+                    }
+                },
+                'username': 'DElenaTimeless',
+                'public_metrics': {
+                    'followers_count': 1772,
+                    'following_count': 854,
+                    'tweet_count': 43347,
+                    'listed_count': 53
+                },
+                'id': '1074184813',
+                'created_at': '2013-01-09T16:04:14.000Z',
+                'profile_image_url': 'https://pbs.twimg.com/profile_images/600743044535554048/DBgKQQMF_normal.jpg',
+                'url': '',
+                'pinned_tweet_id': '857131921427615744',
+                'protected': False,
+                'verified': False,
+                'location': 'The Universe'
+            },
+            {
+                'description': 'Researching & reporting the science & impacts of climate change 🌎 \nRetweets and shares ≠ endorsement | image: Alexander Gerst/NASA',
+                'name': 'Climate Central',
+                'entities': {
+                    'url': {
+                        'urls': [
+                            {
+                                'start': 0,
+                                'end': 23,
+                                'url': 'https://t.co/1I6UpNcrdn',
+                                'expanded_url': 'https://www.climatecentral.org',
+                                'display_url': 'climatecentral.org'
+                            }
+                        ]
+                    }
+                },
+                'username': 'ClimateCentral',
+                'public_metrics': {
+                    'followers_count': 133300,
+                    'following_count': 6920,
+                    'tweet_count': 61042,
+                    'listed_count': 3963
+                },
+                'id': '15463610',
+                'created_at': '2008-07-17T03:30:32.000Z',
+                'profile_image_url': 'https://pbs.twimg.com/profile_images/1148257751925186560/3AUI4s1P_normal.png',
+                'url': 'https://t.co/1I6UpNcrdn',
+                'protected': False,
+                'verified': True,
+                'location': 'Princeton, NJ'
+            }
+        ],
+        'tweets': [
+            {
+                'reply_settings': 'everyone',
+                'referenced_tweets': [
+                    {
+                        'type': 'quoted',
+                        'id': '878622618886094848'
+                    }
+                ],
+                'text': 'Wildfire season in the American West is now two and a half months longer than it was 40 years ago. Our wildfire report in @YEARSofLIVING ⬇️ https://t.co/nk49r9sS1a',
+                'id': '918436293247406080',
+                'entities': {
+                    'annotations': [
+                        {
+                            'start': 23,
+                            'end': 35,
+                            'probability': 0.472,
+                            'type': 'Place',
+                            'normalized_text': 'American West'
+                        }
+                    ],
+                    'mentions': [
+                        {
+                            'start': 122,
+                            'end': 136,
+                            'username': 'YEARSofLIVING',
+                            'id': '308245641'
+                        }
+                    ],
+                    'urls': [
+                        {
+                            'start': 140,
+                            'end': 163,
+                            'url': 'https://t.co/nk49r9sS1a',
+                            'expanded_url': 'https://twitter.com/yearsofliving/status/878622618886094848',
+                            'display_url': 'twitter.com/yearsofliving/…'
+                        }
+                    ]
+                },
+                'possibly_sensitive': False,
+                'conversation_id': '918436293247406080',
+                'public_metrics': {
+                    'retweet_count': 168,
+                    'reply_count': 7,
+                    'like_count': 99,
+                    'quote_count': 3
+                },
+                'lang': 'en',
+                'author_id': '15463610',
+                'source': 'Twitter for iPhone',
+                'created_at': '2017-10-12T11:20:50.000Z'
+            }
+        ]
+    }
 }

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -353,12 +353,13 @@ class TwitterHarvester(BaseHarvester):
 
     def _harvest_tweets_2(self, tweets, limit=None):
         # max_tweet_id = None
-        for page in tweets:
+        # Counter for paginated tweets
+        for i, page in enumerate(tweets):
             if 'data' not in page:
                 return
             for count, tweet in enumerate(page['data']):
-                if not count % 100:
-                    log.debug("Harvested %s tweets", count)
+                if not (count + 1) % 100:
+                    log.debug("Harvested %s tweets", (count + 1) * (i + 1))
                 self.result.harvest_counter["tweets"] += 1
                 if limit and self.result.harvest_counter["tweets"] >= limit:
                     log.debug("Stopping since limit reached.")

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from __future__ import absolute_import
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 import logging
 import re
 import json
@@ -9,6 +9,7 @@ import pytz
 import requests
 
 from twarc import Twarc, Twarc2
+from twarc.decorators2 import _snowflake2millis, _millis2date
 from sfmutils.harvester import BaseHarvester, Msg
 from twitter_stream_warc_iter import TwitterStreamWarcIter
 from twitter_rest_warc_iter import TwitterRestWarcIter, TwitterRestWarcIter2
@@ -25,6 +26,28 @@ ACADEMIC_SEARCH_ROUTING_KEY = "harvest.start.twitter2.twitter_academic_search"
 
 status_re = re.compile("^https://twitter.com/.+/status/\d+$")
 
+def since_id_to_timestamp(since_id):
+    '''
+    Convert a Twitter since_id to a tz-aware timestamp.
+    :param since_id: an integer
+    '''
+    since_dt = _millis2date(_snowflake2millis(since_id))
+    # Need to make this timestamp TZ aware (on the assumption that it's UTC to begin with)
+    return since_dt.replace(tzinfo=timezone.utc)
+
+def check_timedelta(timestamp, offset_days=7):
+    '''
+    Given a UTC timestamp, check its validity vis-a-vis the allowed window.
+    :param timsetamp: a tz-aware datetime object in UTC timezone
+    :param offset_days: the number of days prior to the current moment to check against the since_id
+    '''
+    today = datetime.now(timezone.utc)
+    delta = timedelta(days=offset_days)
+    # Is the timestamp more recent than offset_days?
+    if today - delta <= timestamp:
+        return timestamp
+    else:
+        return None
 
 class TwitterHarvester(BaseHarvester):
     def __init__(self, working_path, stream_restart_interval_secs=30 * 60, mq_config=None, debug=False,
@@ -49,7 +72,7 @@ class TwitterHarvester(BaseHarvester):
             self.search_2()
         elif harvest_type == "twitter_academic_search":
             self._create_twarc2()
-            self.search_2()
+            self.search_2(harvest_type=harvest_type)
         elif harvest_type == "twitter_filter":
             self._create_twarc()
             self.filter()
@@ -97,7 +120,10 @@ class TwitterHarvester(BaseHarvester):
         query, geocode = self._search_parameters()
         self._harvest_tweets(self.twarc.search(query, geocode=geocode, since_id=since_id))
     
-    def search_2(self):
+    def search_2(self, harvest_type="twitter_search_2"):
+        '''
+        :param harvest_type: str of the harvest type (to differentiate behaviors between search_recent and search_all (Academic Search))
+        '''
         assert len(self.message.get("seeds", [])) == 1
 
         incremental = self.message.get("options", {}).get("incremental", False)
@@ -105,6 +131,15 @@ class TwitterHarvester(BaseHarvester):
         since_id = self.state_store.get_state(__name__,
                                               u"{}.since_id".format(self._search_id())) if incremental else None
         query, geocode, start_time, end_time, limit = self._search_parameters2()
+        # Checks necessary for the search_recent endpoint
+        if (harvest_type == "twitter_search_2"):
+            # If since_id is older than 7 days, ignore
+            if since_id and not check_timedelta(since_id_to_timestamp(since_id)):
+                since_id = None
+            # Ignore the start_time param if outside the window for recent searches
+            # Twitter seems to just ignore the end_time if outside the window
+            if start_time:
+                start_time = check_timedelta(start_time)
         # v.2 API does not allow the conjunction of start/end_time params with since_id
         # Let since_id take precedence
         if since_id:

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -105,6 +105,10 @@ class TwitterHarvester(BaseHarvester):
         since_id = self.state_store.get_state(__name__,
                                               u"{}.since_id".format(self._search_id())) if incremental else None
         query, geocode, start_time, end_time, limit = self._search_parameters2()
+        # v.2 API does not allow the conjunction of start/end_time params with since_id
+        # Let since_id take precedence
+        if since_id:
+            start_time, end_time = None, None
         if self.message.get("options").get("twitter_academic_search", False):
             if geocode is not None:
                 query = "".join([query, " point_radius:[", geocode,"]"])

--- a/twitter_rest_exporter.py
+++ b/twitter_rest_exporter.py
@@ -233,7 +233,10 @@ class TwitterRestExporter2(BaseExporter):
                     for idx, table in enumerate(tables):
                         filepath = "{}_{}.txt".format(base_filepath, str(idx + 1).zfill(3))
                         log.info("Exporting to %s", filepath)
-                        petl.totext(table, filepath, template="{{{}}}\n".format(tables.id_field()))
+                        # Convert Tweet dicts to lists of ID's for petl
+                        id_tbl = [[row['id']] for row in table if row]
+                        id_tbl = [['id']] + id_tbl
+                        petl.totext(id_tbl, filepath, template="{{{}}}\n".format(tables.id_field()))
                 elif export_format in twarc_export_formats:
                     # Disable deduplication, because the BaseWARCIter class already handles that (based on user input)
                     converter = dc.DataFrameConverter(allow_duplicates=True)

--- a/twitter_rest_exporter.py
+++ b/twitter_rest_exporter.py
@@ -40,9 +40,9 @@ class BaseTwitterTwoStatusTable(BaseTable):
         (Probably need to refactor for the sake of greater efficiency, since this creates a new DataFrame for every single Tweet.)
         '''
         dfc = self.DataFrameConverter()
-        df = dfc.process(item)
+        df = dfc.process([item])
         # DataFrame.values returns an array of rows -- we want only a single row
-        return df.values[0]
+        return df.fillna('').values[0]
 
     def id_field(self):
         return "id"

--- a/twitter_rest_exporter.py
+++ b/twitter_rest_exporter.py
@@ -4,15 +4,17 @@ import logging
 import twarc.json2csv
 import argparse
 from twarc_csv import dataframe_converter
+import sys
 
 log = logging.getLogger(__name__)
 
 QUEUE = "twitter_rest_exporter"
 SEARCH_ROUTING_KEY = "export.start.twitter.twitter_search"
 TIMELINE_ROUTING_KEY = "export.start.twitter.twitter_user_timeline"
-SEARCH2_ROUTING_KEY = "harvest.start.twitter2.twitter_search_2"
-TIMELINE2_ROUTING_KEY = "harvest.start.twitter2.twitter_user_timeline_2"
-ACADEMIC_SEARCH_ROUTING_KEY = "harvest.start.twitter2.twitter_academic_search"
+QUEUE2 = "twitter_rest_exporter2"
+SEARCH2_ROUTING_KEY = "export.start.twitter2.twitter_search_2"
+TIMELINE2_ROUTING_KEY = "export.start.twitter2.twitter_user_timeline_2"
+ACADEMIC_SEARCH_ROUTING_KEY = "export.start.twitter2.twitter_academic_search"
 
 class BaseTwitterTwoStatusTable(BaseTable):
     """
@@ -111,7 +113,7 @@ if __name__ == "__main__":
     args, extras = parser.parse_known_args()
     sys.argv = sys.argv[:1] + extras
     if args.twitter_version == '2':
-        TwitterRestExporter2.main(TwitterRestExporter2, QUEUE, [SEARCH2_ROUTING_KEY, TIMELINE2_ROUTING_KEY, ACADEMIC_SEARCH_ROUTING_KEY])
+        TwitterRestExporter2.main(TwitterRestExporter2, QUEUE2, [SEARCH2_ROUTING_KEY, TIMELINE2_ROUTING_KEY, ACADEMIC_SEARCH_ROUTING_KEY])
     else:
         TwitterRestExporter.main(TwitterRestExporter, QUEUE,
                              [SEARCH_ROUTING_KEY, TIMELINE_ROUTING_KEY])

--- a/twitter_rest_exporter.py
+++ b/twitter_rest_exporter.py
@@ -5,7 +5,7 @@ import twarc.json2csv
 import argparse
 from twarc_csv import dataframe_converter as dc
 import sys
-from sfmutils.exporter import ExportResult, to_xlsx, to_lineoriented_json
+from sfmutils.exporter import ExportResult, to_xlsx, to_lineoriented_json, CODE_WARC_MISSING, CODE_NO_WARCS, CODE_BAD_REQUEST
 from sfmutils.utils import datetime_now
 import iso8601
 import os
@@ -147,7 +147,10 @@ def to_twarc2_table(table, filepath, converter, format='csv'):
             # Turn off URL encoding for Excel, otherwise we get warnings 
             with pd.ExcelWriter(filepath, engine='xlsxwriter', mode='w', engine_kwargs={'options': {'strings_to_urls': False}}) as writer:
                 df.to_excel(writer, index=False, header=True)
-
+        elif format == 'json':
+            # Write to JSON-L format
+            # May need to incorporate custom handler from exporter.py
+            df.to_json(filepath, orient='records', lines=True, date_format='iso')
 
 
 class TwitterRestExporter(BaseExporter):
@@ -213,7 +216,7 @@ class TwitterRestExporter2(BaseExporter):
                 os.makedirs(temp_path)
 
                 # Using pandas/twarc_csv instead of PETL
-                twarc_export_formats = ("csv", "tsv", "xlsx")
+                twarc_export_formats = ("csv", "tsv", "xlsx", "json")
 
                 # Other possibilities: XML, databases, HDFS
                 if export_format == "json_full":

--- a/twitter_rest_exporter.py
+++ b/twitter_rest_exporter.py
@@ -1,13 +1,49 @@
 from sfmutils.exporter import BaseExporter, BaseTable
-from twitter_rest_warc_iter import TwitterRestWarcIter
+from twitter_rest_warc_iter import TwitterRestWarcIter, TwitterRestWarcIter2
 import logging
 import twarc.json2csv
+import argparse
+from twarc_csv import dataframe_converter
 
 log = logging.getLogger(__name__)
 
 QUEUE = "twitter_rest_exporter"
 SEARCH_ROUTING_KEY = "export.start.twitter.twitter_search"
 TIMELINE_ROUTING_KEY = "export.start.twitter.twitter_user_timeline"
+SEARCH2_ROUTING_KEY = "harvest.start.twitter2.twitter_search_2"
+TIMELINE2_ROUTING_KEY = "harvest.start.twitter2.twitter_user_timeline_2"
+ACADEMIC_SEARCH_ROUTING_KEY = "harvest.start.twitter2.twitter_academic_search"
+
+class BaseTwitterTwoStatusTable(BaseTable):
+    """
+    PETL Table for Twitter statuses for v. 2 API.
+    """
+
+    def __init__(self, warc_paths, dedupe, item_date_start, item_date_end,
+                 seed_uids, warc_iter_cls, segment_row_size):
+        self.DataFrameConverter = dataframe_converter.DataFrameConverter
+        BaseTable.__init__(self, warc_paths, dedupe, item_date_start,
+                           item_date_end, seed_uids, warc_iter_cls,
+                           segment_row_size)
+
+    def _header_row(self):
+        '''
+        Returns CSV columns from DataFrameConverter
+        '''
+        return self.DataFrameConverter().columns
+
+    def _row(self, item):
+        '''
+        Returns a single row for the CSV, using the twarc_csv DataFrameConverter class.
+        (Probably need to refactor for the sake of greater efficiency, since this creates a new DataFrame for every single Tweet.)
+        '''
+        dfc = self.DataFrameConverter()
+        df = dfc.process(item)
+        # DataFrame.values returns an array of rows -- we want only a single row
+        return df.values[0]
+
+    def id_field(self):
+        return "id"
 
 
 class BaseTwitterStatusTable(BaseTable):
@@ -31,24 +67,51 @@ class BaseTwitterStatusTable(BaseTable):
         return "id"
 
 
-class TwitterRestStatusTable(BaseTwitterStatusTable):
-    def __init__(self, warc_paths, dedupe, item_date_start, item_date_end,
+def create_twitter_status_table_class(twitter_table_cls, twitter_warc_iter_cls=TwitterRestWarcIter):
+    '''
+    Helper function to create a class dynamically based on the provided arguments.
+    :param twitter_table_cls: should be either BaseTwitterStatusTable or BaseTwitterTwoStatusTable
+    :param twitter_warc_iter_cls: should be either TwitterRestWarcIter or TwitterRestWarcIter2
+    '''
+    class TwitterRestStatusTable(twitter_table_cls):
+        def __init__(self, warc_paths, dedupe, item_date_start, item_date_end,
                  seed_uids, segment_row_size=None):
-        BaseTwitterStatusTable.__init__(self, warc_paths, dedupe,
+            twitter_table_cls.__init__(self, warc_paths, dedupe,
                                         item_date_start, item_date_end,
-                                        seed_uids, TwitterRestWarcIter,
+                                        seed_uids, twitter_warc_iter_cls,
                                         segment_row_size)
+    
+    return TwitterRestStatusTable
 
 
 class TwitterRestExporter(BaseExporter):
     def __init__(self, api_base_url, working_path, mq_config=None,
                  warc_base_path=None):
+        TwitterRestStatusTable = create_twitter_status_table_class(BaseTwitterStatusTable, TwitterRestWarcIter)
         BaseExporter.__init__(self, api_base_url, TwitterRestWarcIter,
+                              TwitterRestStatusTable, working_path,
+                              mq_config=mq_config,
+                              warc_base_path=warc_base_path)
+
+class TwitterRestExporter2(BaseExporter):
+    def __init__(self, api_base_url, working_path, mq_config=None,
+                 warc_base_path=None):
+        TwitterRestStatusTable = create_twitter_status_table_class(BaseTwitterTwoStatusTable, TwitterRestWarcIter2)
+        BaseExporter.__init__(self, api_base_url, TwitterRestWarcIter2,
                               TwitterRestStatusTable, working_path,
                               mq_config=mq_config,
                               warc_base_path=warc_base_path)
 
 
 if __name__ == "__main__":
-    TwitterRestExporter.main(TwitterRestExporter, QUEUE,
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--twitter_version", default='2')
+    # To remove argument before passing to the wrapped function
+    # Following example here: https://stackoverflow.com/questions/35733262/is-there-any-way-to-instruct-argparse-python-2-7-to-remove-found-arguments-fro
+    args, extras = parser.parse_known_args()
+    sys.argv = sys.argv[:1] + extras
+    if args.twitter_version == '2':
+        TwitterRestExporter2.main(TwitterRestExporter2, QUEUE, [SEARCH2_ROUTING_KEY, TIMELINE2_ROUTING_KEY, ACADEMIC_SEARCH_ROUTING_KEY])
+    else:
+        TwitterRestExporter.main(TwitterRestExporter, QUEUE,
                              [SEARCH_ROUTING_KEY, TIMELINE_ROUTING_KEY])

--- a/twitter_rest_exporter.py
+++ b/twitter_rest_exporter.py
@@ -176,7 +176,7 @@ class TwitterRestExporter2(BaseExporter):
         assert self.message
         export_id = self.message["id"]
         log.info("Performing export %s", export_id)
-
+        log.debug(self.message)
         self.result = ExportResult()
         self.result.started = datetime_now()
 
@@ -231,8 +231,8 @@ class TwitterRestExporter2(BaseExporter):
                         log.info("Exporting to %s", filepath)
                         petl.totext(table, filepath, template="{{{}}}\n".format(tables.id_field()))
                 elif export_format in twarc_export_formats:
-                    # Using default options -- need to check for cases when that may not be desired
-                    converter = dc.DataFrameConverter()
+                    # Disable deduplication, because the BaseWARCIter class already handles that (based on user input)
+                    converter = dc.DataFrameConverter(allow_duplicates=True)
                     # Can't append to xlsx files from DataFrames using the xlsxwriter engine, so we need to limit the file sizes to the largest size of DataFrame we are willing to accommodate
                     if export_format == 'xlsx':
                         export_segment_size = MAX_DATAFRAME_ROWS

--- a/twitter_rest_exporter.py
+++ b/twitter_rest_exporter.py
@@ -150,7 +150,8 @@ def to_twarc2_table(table, filepath, converter, format='csv'):
         elif format == 'json':
             # Write to JSON-L format
             # May need to incorporate custom handler from exporter.py
-            df.to_json(filepath, orient='records', lines=True, date_format='iso')
+            with open(filepath, mode=mode) as f:
+                df.to_json(f, orient='records', lines=True, date_format='iso')
 
 
 class TwitterRestExporter(BaseExporter):

--- a/twitter_rest_warc_iter.py
+++ b/twitter_rest_warc_iter.py
@@ -7,6 +7,8 @@ from dateutil.parser import parse as date_parse
 import json
 import sys
 
+from twarc.expansions import ensure_flattened
+
 SEARCH_URL = "https://api.twitter.com/1.1/search/tweets.json"
 TIMELINE_URL = "https://api.twitter.com/1.1/statuses/user_timeline.json"
 SEARCH_URL_2 = re.compile(r"https://api.twitter.com/2/tweets/(?:search/(?:recent|all)|sample/stream)")
@@ -52,8 +54,8 @@ class TwitterRestWarcIter2(BaseWarcIter):
         # Ignore error messages
         if not isinstance(json_obj, dict) or not 'data' in json_obj:
             return
-        # Both search and timeline hold a list of tweets in "data"
-        tweet_list = json_obj.get("data", [])
+        # Both search and timeline hold a list of tweets in "data" but need to be "flattened" to include expansions
+        tweet_list = ensure_flattened(json_obj)
         for status in tweet_list:
             yield "twitter_status", status["id"], date_parse(status["created_at"]), status
 

--- a/twitter_rest_warc_iter.py
+++ b/twitter_rest_warc_iter.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from __future__ import absolute_import
+import re
 from sfmutils.warc_iter import BaseWarcIter
 from dateutil.parser import parse as date_parse
 import json
@@ -8,7 +9,8 @@ import sys
 
 SEARCH_URL = "https://api.twitter.com/1.1/search/tweets.json"
 TIMELINE_URL = "https://api.twitter.com/1.1/statuses/user_timeline.json"
-
+SEARCH_URL_2 = re.compile(r"https://api.twitter.com/2/tweets/(?:search/(?:recent|all)|sample/stream)")
+TIMELINE_URL_2 = re.compile(r"https://api.twitter.com/2/users/[^/]+/(?:tweets|mentions)")
 
 class TwitterRestWarcIter(BaseWarcIter):
     def __init__(self, filepaths, limit_user_ids=None):
@@ -27,6 +29,33 @@ class TwitterRestWarcIter(BaseWarcIter):
         tweet_list = json_obj.get("statuses", []) if url.startswith(SEARCH_URL) else json_obj
         for status in tweet_list:
             yield "twitter_status", status["id_str"], date_parse(status["created_at"]), status
+
+    @staticmethod
+    def item_types():
+        return ["twitter_status"]
+
+    def _select_item(self, item):
+        if not self.limit_user_ids or item.get("user", {}).get("id_str") in self.limit_user_ids:
+            return True
+        return False
+
+
+class TwitterRestWarcIter2(BaseWarcIter):
+    def __init__(self, filepaths, limit_user_ids=None):
+        BaseWarcIter.__init__(self, filepaths)
+        self.limit_user_ids = limit_user_ids
+
+    def _select_record(self, url):
+        return SEARCH_URL_2.match(url) or TIMELINE_URL_2.match(url)
+
+    def _item_iter(self, url, json_obj):
+        # Ignore error messages
+        if not isinstance(json_obj, dict) or not 'data' in json_obj:
+            return
+        # Both search and timeline hold a list of tweets in "data"
+        tweet_list = json_obj.get("data", [])
+        for status in tweet_list:
+            yield "twitter_status", status["id"], date_parse(status["created_at"]), status
 
     @staticmethod
     def item_types():


### PR DESCRIPTION
#### Summary

Updates harvester and exporter for Twitter v. 2 search and timeline types. Test in conjunction with `twitter-v2` branch in `sfm-ui` and `t1103-twitter-v2-search` branch in `sfm-utils`. (Note that this PR includes code both for the v2. harvester and the v2. exporter.)

#### To prepare

1. Update `docker-compose.yml` to use the v2 Twitter rest exporter as well as the existing exporter. See `example.docker-compose.yml` in the `t1103-twitter2-exporter` branch of `sfm-docker`. 
2. Change the compose file to build the local image for **both** the `twitterrestexporter` and the `twitterrestexporter2` services. 
3. Make sure both services are using code from the locally mapped volumes.

#### To test

1. Create collections for the Twitter 2 search and Twitter 2 user timeline harvest types.
2. Make sure collections harvest without errors.
3. Create exports of all types from these collections.
4. Create exports of all types from Twitter v1 search and Twitter v1 user timeline collections.