### PR TITLE
T1104 v2 filter stream

### DIFF
--- a/Dockerfile-stream-exporter
+++ b/Dockerfile-stream-exporter
@@ -10,4 +10,5 @@ RUN pip install -r requirements/common.txt -r requirements/${build_version}.txt
 ADD docker/stream-exporter/invoke.sh /opt/sfm-setup/
 RUN chmod +x /opt/sfm-setup/invoke.sh
 
-CMD ["/opt/sfm-setup/invoke.sh"]
+ENTRYPOINT ["/opt/sfm-setup/invoke.sh"] 
+CMD ["2"]

--- a/Dockerfile-stream-exporter-v2
+++ b/Dockerfile-stream-exporter-v2
@@ -11,3 +11,4 @@ ADD docker/stream-exporter/invoke.sh /opt/sfm-setup/
 RUN chmod +x /opt/sfm-setup/invoke.sh
 
 ENTRYPOINT ["/opt/sfm-setup/invoke.sh"] 
+CMD ["2"]

--- a/docker/stream-exporter/invoke.sh
+++ b/docker/stream-exporter/invoke.sh
@@ -7,4 +7,4 @@ echo "Waiting for dependencies"
 appdeps.py --wait-secs 60 --port-wait ${SFM_RABBITMQ_HOST}:${SFM_RABBITMQ_PORT} --port-wait api:8080 --file-wait /sfm-collection-set-data/collection_set --file-wait /sfm-containers-data/containers --file-wait /sfm-export-data/export \
 
 echo "Starting harvester"
-exec gosu sfm python twitter_stream_exporter.py --debug=$DEBUG service $SFM_RABBITMQ_HOST $SFM_RABBITMQ_USER $SFM_RABBITMQ_PASSWORD http://api:8080 /sfm-containers-data/containers/$HOSTNAME
+exec gosu sfm python twitter_stream_exporter.py --debug=$DEBUG service $SFM_RABBITMQ_HOST $SFM_RABBITMQ_USER $SFM_RABBITMQ_PASSWORD http://api:8080 /sfm-containers-data/containers/$HOSTNAME --twitter_version=${1:-1}

--- a/docker/stream-harvester/invoke.sh
+++ b/docker/stream-harvester/invoke.sh
@@ -20,4 +20,4 @@ supervisord -c /etc/supervisor/supervisord.conf
 
 echo "Starting stream consumer"
 # exec makes this take the pid of the script, which should be pid 1.
-exec stream_consumer.py $SFM_RABBITMQ_HOST $SFM_RABBITMQ_USER $SFM_RABBITMQ_PASSWORD twitter_harvester harvest.start.twitter.twitter_filter,harvest.start.twitter.twitter_sample /opt/sfm-twitter-harvester/twitter_harvester.py /sfm-containers-data/containers/$HOSTNAME --debug=$DEBUG --debug-warcprox=$DEBUG_WARCPROX --tries=$HARVEST_TRIES
+exec stream_consumer.py $SFM_RABBITMQ_HOST $SFM_RABBITMQ_USER $SFM_RABBITMQ_PASSWORD twitter_harvester harvest.start.twitter.twitter_filter,harvest.start.twitter.twitter_sample,harvest.start.twitter2.twitter_filter_stream /opt/sfm-twitter-harvester/twitter_harvester.py /sfm-containers-data/containers/$HOSTNAME --debug=$DEBUG --debug-warcprox=$DEBUG_WARCPROX --tries=$HARVEST_TRIES

--- a/docker/stream-harvester/invoke.sh
+++ b/docker/stream-harvester/invoke.sh
@@ -20,4 +20,4 @@ supervisord -c /etc/supervisor/supervisord.conf
 
 echo "Starting stream consumer"
 # exec makes this take the pid of the script, which should be pid 1.
-exec stream_consumer.py $SFM_RABBITMQ_HOST $SFM_RABBITMQ_USER $SFM_RABBITMQ_PASSWORD twitter_harvester harvest.start.twitter.twitter_filter,harvest.start.twitter.twitter_sample,harvest.start.twitter2.twitter_filter_stream /opt/sfm-twitter-harvester/twitter_harvester.py /sfm-containers-data/containers/$HOSTNAME --debug=$DEBUG --debug-warcprox=$DEBUG_WARCPROX --tries=$HARVEST_TRIES
+exec stream_consumer.py $SFM_RABBITMQ_HOST $SFM_RABBITMQ_USER $SFM_RABBITMQ_PASSWORD twitter_harvester harvest.start.twitter.twitter_filter,harvest.start.twitter2.twitter_filter_stream /opt/sfm-twitter-harvester/twitter_harvester.py /sfm-containers-data/containers/$HOSTNAME --debug=$DEBUG --debug-warcprox=$DEBUG_WARCPROX --tries=$HARVEST_TRIES

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,5 +1,5 @@
-twarc==2.12.0
-twarc-csv==0.6.0
+twarc==2.13.0
+twarc-csv==0.7.1
 python-dateutil==2.8.2
 
 # Master support Py3, but no release. This should be in sfm-utils setup.py once released.

--- a/tests/test_twitter_harvester.py
+++ b/tests/test_twitter_harvester.py
@@ -522,7 +522,7 @@ class TestTwitterHarvester2(tests.TestCase):
     def test_user_timeline_2(self, mock_twarc_class):
         mock_twarc = MagicMock(spec=Twarc2)
         # Expecting 2 user timelines. First returns 2 tweets. Second returns none.
-        mock_twarc.timeline.side_effect = [[join_tweets(tweet1_2, tweet2_2), ()]]
+        mock_twarc.timeline.side_effect = [[join_tweets(tweet1_2, tweet2_2)], [()]]
         # Expecting 2 calls to get for user lookup
         mock_response1 = MagicMock()
         mock_response1.status_code = 200
@@ -551,7 +551,7 @@ class TestTwitterHarvester2(tests.TestCase):
 
         mock_twarc = MagicMock(spec=Twarc2)
         # Expecting 2 timelines. First returns 1 tweets. Second returns none.
-        mock_twarc.timeline.side_effect = [[tweet2_2, ()]]
+        mock_twarc.timeline.side_effect = [[tweet2_2], [()]]
         # Expecting 2 calls to get for user lookup
         mock_response1 = MagicMock()
         mock_response1.status_code = 200

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -473,23 +473,23 @@ class TwitterHarvester(BaseHarvester):
         # max_tweet_id = None
         # Counter for paginated tweets
         for i, page in enumerate(tweets):        
-            for page in tweets:
-                if 'data' not in page:
-                    return
-                for count, tweet in enumerate(page['data']):
-                    if not (count + 1) % 100:
-                        log.debug("Harvested %s tweets", (count + 1) * (i + 1))
-                    self.result.harvest_counter["tweets"] += 1
-                    if limit and self.result.harvest_counter["tweets"] >= limit:
-                        log.debug("Stopping since limit reached.")
-                        self.stop_harvest_seeds_event.set()
-                        #break
-                    if self.stop_harvest_seeds_event.is_set():
-                        log.debug("Stopping since stop event set.")
-                        break
-                else:
-                    continue  
-                break
+            
+            if 'data' not in page:
+                return
+            for count, tweet in enumerate(page['data']):
+                if not (count + 1) % 100:
+                    log.debug("Harvested %s tweets", (count + 1) * (i + 1))
+                self.result.harvest_counter["tweets"] += 1
+                if limit and self.result.harvest_counter["tweets"] >= limit:
+                    log.debug("Stopping since limit reached.")
+                    self.stop_harvest_seeds_event.set()
+                    #break
+                if self.stop_harvest_seeds_event.is_set():
+                    log.debug("Stopping since stop event set.")
+                    break
+            else:
+                continue  
+            break
 
 
     # for stream

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -91,7 +91,7 @@ class TwitterHarvester(BaseHarvester):
 
         #stream new code 
 
-        elif harvest_type == "stream":
+        elif harvest_type == "twitter_filter_stream":
             self._create_twarc2()
             self.stream_2()
 
@@ -527,7 +527,7 @@ class TwitterHarvester(BaseHarvester):
         elif harvest_type == "twitter_filter":
             self._process_tweets(TwitterStreamWarcIter(warc_filepath))
         #code for filter stream
-        elif harvest_type == "stream":
+        elif harvest_type == "twitter_filter_stream":
             self._process_tweets_2(TwitterStreamWarcIter2(warc_filepath))
         #code end for for filter stream
         elif harvest_type == "twitter_sample":

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -26,6 +26,7 @@ TIMELINE_ROUTING_KEY = "harvest.start.twitter.twitter_user_timeline"
 SEARCH2_ROUTING_KEY = "harvest.start.twitter2.twitter_search_2"
 TIMELINE2_ROUTING_KEY = "harvest.start.twitter2.twitter_user_timeline_2"
 ACADEMIC_SEARCH_ROUTING_KEY = "harvest.start.twitter2.twitter_academic_search"
+FILTER_STREAM_ROUTING_KEY = "harvest.start.twitter2.twitter_filter_stream"
 
 status_re = re.compile("^https://twitter.com/.+/status/\d+$")
 
@@ -632,4 +633,4 @@ class TwitterHarvester(BaseHarvester):
 
 
 if __name__ == "__main__":
-    TwitterHarvester.main(TwitterHarvester, QUEUE, [SEARCH_ROUTING_KEY, TIMELINE_ROUTING_KEY, SEARCH2_ROUTING_KEY, TIMELINE2_ROUTING_KEY, ACADEMIC_SEARCH_ROUTING_KEY])
+    TwitterHarvester.main(TwitterHarvester, QUEUE, [SEARCH_ROUTING_KEY, TIMELINE_ROUTING_KEY, SEARCH2_ROUTING_KEY, TIMELINE2_ROUTING_KEY, ACADEMIC_SEARCH_ROUTING_KEY,FILTER_STREAM_ROUTING_KEY])

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -480,8 +480,8 @@ class TwitterHarvester(BaseHarvester):
                 log.debug("Stopping since stop event set.")
                 break
 
-    def _harvest_tweets_2(self, tweets, limit=None):
-        for i, page in enumerate(tweets):        
+    def _harvest_tweets_2(self, pages, limit=None):
+        for i, page in enumerate(pages):        
             if 'data' not in page:
                 return
             for count, tweet in enumerate(page['data']):
@@ -491,10 +491,10 @@ class TwitterHarvester(BaseHarvester):
                 if limit and self.result.harvest_counter["tweets"] >= limit:
                     log.debug("Stopping since limit reached.")
                     self.stop_harvest_seeds_event.set()
-                    break
+                    #break
             if self.stop_harvest_seeds_event.is_set():
                 log.debug("Stopping since stop event set.")
-                break
+                return
 
     def _process_tweets_stream(self, tweets,limit=None):
         for count, tweet in enumerate(tweets):

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from __future__ import absolute_import
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 import logging
 import re
 import json
@@ -10,6 +10,7 @@ import requests
 import threading #stream code
 
 from twarc import Twarc, Twarc2
+from twarc.decorators2 import _snowflake2millis, _millis2date
 from sfmutils.harvester import BaseHarvester, Msg
 from twitter_stream_warc_iter import TwitterStreamWarcIter
 from twitter_stream_warc_iter import TwitterStreamWarcIter2
@@ -27,6 +28,29 @@ TIMELINE2_ROUTING_KEY = "harvest.start.twitter2.twitter_user_timeline_2"
 ACADEMIC_SEARCH_ROUTING_KEY = "harvest.start.twitter2.twitter_academic_search"
 
 status_re = re.compile("^https://twitter.com/.+/status/\d+$")
+
+def since_id_to_timestamp(since_id):
+    '''
+    Convert a Twitter since_id to a tz-aware timestamp.
+    :param since_id: an integer
+    '''
+    since_dt = _millis2date(_snowflake2millis(since_id))
+    # Need to make this timestamp TZ aware (on the assumption that it's UTC to begin with)
+    return since_dt.replace(tzinfo=timezone.utc)
+
+def check_timedelta(timestamp, offset_days=7):
+    '''
+    Given a UTC timestamp, check its validity vis-a-vis the allowed window.
+    :param timsetamp: a tz-aware datetime object in UTC timezone
+    :param offset_days: the number of days prior to the current moment to check against the since_id
+    '''
+    today = datetime.now(timezone.utc)
+    delta = timedelta(days=offset_days)
+    # Is the timestamp more recent than offset_days?
+    if today - delta <= timestamp:
+        return timestamp
+    else:
+        return None
 
 class TwitterHarvester(BaseHarvester):
     def __init__(self, working_path, stream_restart_interval_secs=30 * 60, mq_config=None, debug=False,
@@ -51,7 +75,7 @@ class TwitterHarvester(BaseHarvester):
             self.search_2()
         elif harvest_type == "twitter_academic_search":
             self._create_twarc2()
-            self.search_2()
+            self.search_2(harvest_type=harvest_type)
         elif harvest_type == "twitter_filter":
             self._create_twarc()
             self.filter()
@@ -108,7 +132,12 @@ class TwitterHarvester(BaseHarvester):
         query, geocode = self._search_parameters()
         self._harvest_tweets(self.twarc.search(query, geocode=geocode, since_id=since_id))
     
-    def search_2(self):
+
+    def search_2(self, harvest_type="twitter_search_2"):
+        '''
+        :param harvest_type: str of the harvest type (to differentiate behaviors between search_recent and search_all (Academic Search))
+        '''
+
         assert len(self.message.get("seeds", [])) == 1
 
         incremental = self.message.get("options", {}).get("incremental", False)
@@ -116,6 +145,19 @@ class TwitterHarvester(BaseHarvester):
         since_id = self.state_store.get_state(__name__,
                                               u"{}.since_id".format(self._search_id())) if incremental else None
         query, geocode, start_time, end_time, limit = self._search_parameters2()
+        # Checks necessary for the search_recent endpoint
+        if (harvest_type == "twitter_search_2"):
+            # If since_id is older than 7 days, ignore
+            if since_id and not check_timedelta(since_id_to_timestamp(since_id)):
+                since_id = None
+            # Ignore the start_time param if outside the window for recent searches
+            # Twitter seems to just ignore the end_time if outside the window
+            if start_time:
+                start_time = check_timedelta(start_time)
+        # v.2 API does not allow the conjunction of start/end_time params with since_id
+        # Let since_id take precedence
+        if since_id:
+            start_time, end_time = None, None
         if self.message.get("options").get("twitter_academic_search", False):
             if geocode is not None:
                 query = "".join([query, " point_radius:[", geocode,"]"])
@@ -418,6 +460,7 @@ class TwitterHarvester(BaseHarvester):
         return "not found or deleted"
 
     def _harvest_tweets(self, tweets):
+        # max_tweet_id = None
         for count, tweet in enumerate(tweets):
             if not count % 100:
                 log.debug("Harvested %s tweets", count)
@@ -427,23 +470,26 @@ class TwitterHarvester(BaseHarvester):
                 break
 
     def _harvest_tweets_2(self, tweets, limit=None):
-        for page in tweets:
-            if 'data' not in page:
-                return
-            for count, tweet in enumerate(page['data']):
-                if not count % 100:                    
-                    log.debug("Harvested %s tweets", count)
-                self.result.harvest_counter["tweets"] += 1
-                if limit and self.result.harvest_counter["tweets"] >= limit:
-                    log.debug("Stopping since limit reached.")
-                    self.stop_harvest_seeds_event.set()
-                    #break
-                if self.stop_harvest_seeds_event.is_set():
-                    log.debug("Stopping since stop event set.")
-                    break
-            else:
-                continue  
-            break
+        # max_tweet_id = None
+        # Counter for paginated tweets
+        for i, page in enumerate(tweets):        
+            for page in tweets:
+                if 'data' not in page:
+                    return
+                for count, tweet in enumerate(page['data']):
+                    if not (count + 1) % 100:
+                        log.debug("Harvested %s tweets", (count + 1) * (i + 1))
+                    self.result.harvest_counter["tweets"] += 1
+                    if limit and self.result.harvest_counter["tweets"] >= limit:
+                        log.debug("Stopping since limit reached.")
+                        self.stop_harvest_seeds_event.set()
+                        #break
+                    if self.stop_harvest_seeds_event.is_set():
+                        log.debug("Stopping since stop event set.")
+                        break
+                else:
+                    continue  
+                break
 
 
     # for stream

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -75,6 +75,7 @@ def v2_error_handling(f):
             elif title == "UsageCapExceeded":
                 msg = f"Monthly usage cap exceeded with these API credentials. Please check the Twitter Developer portal for more information about your account."
             else:
+                log.debug(resp_json)
                 raise e
             title = title.replace(" ", "_")
             self.result.errors.append(Msg(f"harvest_{title}", msg))

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -254,6 +254,10 @@ class TwitterHarvester(BaseHarvester):
         e = threading.Event()
         #self._harvest_tweets_2(self.twarc.stream(event=e,record_keepalive=False),limit=100)
         self._process_tweets_stream(self.twarc.stream(event=e,record_keepalive=False),limit=500)
+
+        #self._harvest_tweets_2(self.twarc.stream(event=e,record_keepalive=False),limit=500)
+
+        
         
         
         

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -78,7 +78,6 @@ def v2_error_handling(f):
                 raise e
             title = title.replace(" ", "_")
             self.result.errors.append(Msg(f"harvest_{title}", msg))
-            #raise e
             self.result.success = False
     return new_f
 
@@ -249,7 +248,7 @@ class TwitterHarvester(BaseHarvester):
         seeds = self.message["seeds"]
         # Add each seed as a streaming rule
         # TO DO --> Implement user-added tags
-        self.streaming_rules = [{"value": seed["token"].get("rule"), "tag": seed["token"].get("rule") } for seed in seeds]
+        self.streaming_rules = [{"value": seed["token"].get("rule"), "tag": seed["token"].get("tag", seed["token"].get("rule")) } for seed in seeds]
         # Delete any streaming rules currently in place that don't match the current list of rules (seeds)
         old_rules = {r['value']: r['id'] for r in self.twarc.get_stream_rules().get('data', [])}
         rules_to_add = []

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -285,7 +285,8 @@ class TwitterHarvester(BaseHarvester):
                 else:
                     log.error(resp_json)
                     raise e
-    
+                    
+    @v2_error_handling
     def stream_2(self):
         '''
         Dispatches to Twarc2 streaming method. 

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -453,7 +453,7 @@ class TwitterHarvester(BaseHarvester):
                 # This allows the harvester to stop if the limit is reached
                 # TO DO -> trigger the UI to "Turn Off" the harvest
                 # May need to replicate code from sfm-utils/harvester.py:184
-                self.stop_harvest_loop_event.set()
+                #self.stop_harvest_loop_event.set()
                 break
 
     def process_warc(self, warc_filepath):

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -226,7 +226,7 @@ class TwitterHarvester(BaseHarvester):
     def stream_2(self):
 
         
-
+        '''
         # remove any active stream rules
         rules = self.twarc.get_stream_rules()
         if "data" in rules and len(rules["data"]) > 0:
@@ -251,6 +251,7 @@ class TwitterHarvester(BaseHarvester):
 
         #log.debug("rules Adhithya Kiran",rules["data"])
         #log.debug("rules lenght Adhithya Kiran",len(rules["data"]))
+        '''
         e = threading.Event()
         #self._harvest_tweets_2(self.twarc.stream(event=e,record_keepalive=False),limit=100)
         self._process_tweets_stream(self.twarc.stream(event=e,record_keepalive=False),limit=500)

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -84,6 +84,8 @@ def v2_error_handling(f):
             title = title.replace(" ", "_")
             self.result.errors.append(Msg(f"harvest_{title}", msg))
             self.result.success = False
+            # For streaming harvesters: necessary to interrupt the harvest
+            self.stop_harvest_loop_event.set()
     return new_f
 
 class TwitterHarvester(BaseHarvester):

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python3
 
 from __future__ import absolute_import
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 import logging
 import re
 import json
 import pytz
 import requests
+import threading #stream code
 
 from twarc import Twarc, Twarc2
-from twarc.decorators2 import _snowflake2millis, _millis2date
 from sfmutils.harvester import BaseHarvester, Msg
 from twitter_stream_warc_iter import TwitterStreamWarcIter
+from twitter_stream_warc_iter import TwitterStreamWarcIter2
 from twitter_rest_warc_iter import TwitterRestWarcIter, TwitterRestWarcIter2
+from twarc import Twarc2, expansions  #stream code
 
 log = logging.getLogger(__name__)
 
@@ -25,29 +27,6 @@ TIMELINE2_ROUTING_KEY = "harvest.start.twitter2.twitter_user_timeline_2"
 ACADEMIC_SEARCH_ROUTING_KEY = "harvest.start.twitter2.twitter_academic_search"
 
 status_re = re.compile("^https://twitter.com/.+/status/\d+$")
-
-def since_id_to_timestamp(since_id):
-    '''
-    Convert a Twitter since_id to a tz-aware timestamp.
-    :param since_id: an integer
-    '''
-    since_dt = _millis2date(_snowflake2millis(since_id))
-    # Need to make this timestamp TZ aware (on the assumption that it's UTC to begin with)
-    return since_dt.replace(tzinfo=timezone.utc)
-
-def check_timedelta(timestamp, offset_days=7):
-    '''
-    Given a UTC timestamp, check its validity vis-a-vis the allowed window.
-    :param timsetamp: a tz-aware datetime object in UTC timezone
-    :param offset_days: the number of days prior to the current moment to check against the since_id
-    '''
-    today = datetime.now(timezone.utc)
-    delta = timedelta(days=offset_days)
-    # Is the timestamp more recent than offset_days?
-    if today - delta <= timestamp:
-        return timestamp
-    else:
-        return None
 
 class TwitterHarvester(BaseHarvester):
     def __init__(self, working_path, stream_restart_interval_secs=30 * 60, mq_config=None, debug=False,
@@ -72,7 +51,7 @@ class TwitterHarvester(BaseHarvester):
             self.search_2()
         elif harvest_type == "twitter_academic_search":
             self._create_twarc2()
-            self.search_2(harvest_type=harvest_type)
+            self.search_2()
         elif harvest_type == "twitter_filter":
             self._create_twarc()
             self.filter()
@@ -85,6 +64,15 @@ class TwitterHarvester(BaseHarvester):
         elif harvest_type == "twitter_user_timeline_2":
             self._create_twarc2()
             self.user_timeline_2()
+
+        #stream new code 
+
+        elif harvest_type == "stream":
+            self._create_twarc2()
+            self.stream_2()
+
+        #stream new code ends  
+
         else:
             raise KeyError
 
@@ -120,10 +108,7 @@ class TwitterHarvester(BaseHarvester):
         query, geocode = self._search_parameters()
         self._harvest_tweets(self.twarc.search(query, geocode=geocode, since_id=since_id))
     
-    def search_2(self, harvest_type="twitter_search_2"):
-        '''
-        :param harvest_type: str of the harvest type (to differentiate behaviors between search_recent and search_all (Academic Search))
-        '''
+    def search_2(self):
         assert len(self.message.get("seeds", [])) == 1
 
         incremental = self.message.get("options", {}).get("incremental", False)
@@ -131,19 +116,6 @@ class TwitterHarvester(BaseHarvester):
         since_id = self.state_store.get_state(__name__,
                                               u"{}.since_id".format(self._search_id())) if incremental else None
         query, geocode, start_time, end_time, limit = self._search_parameters2()
-        # Checks necessary for the search_recent endpoint
-        if (harvest_type == "twitter_search_2"):
-            # If since_id is older than 7 days, ignore
-            if since_id and not check_timedelta(since_id_to_timestamp(since_id)):
-                since_id = None
-            # Ignore the start_time param if outside the window for recent searches
-            # Twitter seems to just ignore the end_time if outside the window
-            if start_time:
-                start_time = check_timedelta(start_time)
-        # v.2 API does not allow the conjunction of start/end_time params with since_id
-        # Let since_id take precedence
-        if since_id:
-            start_time, end_time = None, None
         if self.message.get("options").get("twitter_academic_search", False):
             if geocode is not None:
                 query = "".join([query, " point_radius:[", geocode,"]"])
@@ -202,6 +174,71 @@ class TwitterHarvester(BaseHarvester):
 
         self._harvest_tweets(
             self.twarc.filter(track=track, follow=follow, locations=locations, lang=language, event=self.stop_harvest_seeds_event))
+
+
+    #New stream rule
+
+
+
+
+    def stream_2(self):
+
+        
+
+        # remove any active stream rules
+        rules = self.twarc.get_stream_rules()
+        if "data" in rules and len(rules["data"]) > 0:
+            rule_ids = [r["id"] for r in rules["data"]]
+            self.twarc.delete_stream_rule_ids(rule_ids)
+
+        # make sure they are empty
+        rules = self.twarc.get_stream_rules()
+        assert "data" not in rules
+
+        # add two rules
+        rules = self.twarc.add_stream_rules(
+            [{"value": "twitter", "tag": "modwarc-test"}, {"value": "musk", "tag": "tdwarc-test"}]
+        )
+        assert len(rules["data"]) == 2
+
+        # make sure they are there
+        #rules = self.twarc.get_stream_rules()
+        #assert len(rules["data"]) == 2
+
+        #print("rules",rules)
+
+        #log.debug("rules Adhithya Kiran",rules["data"])
+        #log.debug("rules lenght Adhithya Kiran",len(rules["data"]))
+        e = threading.Event()
+        #self._harvest_tweets_2(self.twarc.stream(event=e,record_keepalive=False),limit=100)
+        self._process_tweets_stream(self.twarc.stream(event=e,record_keepalive=False),limit=500)
+        
+        
+        
+        
+
+        #self._harvest_tweets_2(self.twarc.stream())
+
+        
+    #This is working using direct call
+
+    # collect some data 
+        #for count, result in enumerate(self.twarc.stream()):
+        # The Twitter API v2 returns the Tweet information and the user, media etc.  separately
+        # so we use expansions.flatten to get all the information in a single JSON
+            #tweet = expansions.flatten(result)
+        # Here we are printing the full Tweet object JSON to the console
+            #print(json.dumps(tweet))
+            #log.debug("json.dumps(tweet)",json.dumps(tweet))
+        # Replace with the desired number of Tweets
+            #if count > 10:
+                #break
+
+
+        
+
+
+    #end of stream rules
 
     def sample(self):
         self._harvest_tweets(self.twarc.sample(self.stop_harvest_seeds_event))
@@ -381,7 +418,6 @@ class TwitterHarvester(BaseHarvester):
         return "not found or deleted"
 
     def _harvest_tweets(self, tweets):
-        # max_tweet_id = None
         for count, tweet in enumerate(tweets):
             if not count % 100:
                 log.debug("Harvested %s tweets", count)
@@ -391,14 +427,12 @@ class TwitterHarvester(BaseHarvester):
                 break
 
     def _harvest_tweets_2(self, tweets, limit=None):
-        # max_tweet_id = None
-        # Counter for paginated tweets
-        for i, page in enumerate(tweets):
+        for page in tweets:
             if 'data' not in page:
                 return
             for count, tweet in enumerate(page['data']):
-                if not (count + 1) % 100:
-                    log.debug("Harvested %s tweets", (count + 1) * (i + 1))
+                if not count % 100:                    
+                    log.debug("Harvested %s tweets", count)
                 self.result.harvest_counter["tweets"] += 1
                 if limit and self.result.harvest_counter["tweets"] >= limit:
                     log.debug("Stopping since limit reached.")
@@ -410,6 +444,29 @@ class TwitterHarvester(BaseHarvester):
             else:
                 continue  
             break
+
+
+    # for stream
+
+    def _process_tweets_stream(self, tweets,limit=None):
+        max_tweet_id = None
+        for count, tweet in enumerate(tweets):
+            if not count % 100:
+                log.debug("Harvested %s tweets", count)
+            self.result.harvest_counter["tweets"] += 1    
+            if limit and self.result.harvest_counter["tweets"] >= limit:
+                log.debug("Stopping since limit reached.")
+                self.stop_harvest_seeds_event.set()                
+            if self.stop_harvest_seeds_event.is_set():
+                log.debug("Stopping since stop event set.")
+                break
+            else:
+                continue
+
+
+    #end for stream        
+
+
 
     def process_warc(self, warc_filepath):
         # Dispatch message based on type.
@@ -423,6 +480,10 @@ class TwitterHarvester(BaseHarvester):
             self.process_search_warc_2(warc_filepath)
         elif harvest_type == "twitter_filter":
             self._process_tweets(TwitterStreamWarcIter(warc_filepath))
+        #code for filter stream
+        elif harvest_type == "stream":
+            self._process_tweets_2(TwitterStreamWarcIter2(warc_filepath))
+        #code end for for filter stream
         elif harvest_type == "twitter_sample":
             self._process_tweets(TwitterStreamWarcIter(warc_filepath))
         elif harvest_type == "twitter_user_timeline":
@@ -489,6 +550,7 @@ class TwitterHarvester(BaseHarvester):
                                                    int(tweet.get("id"))))
                 self._process_tweet(tweet)
 
+      
     def _process_tweets(self, warc_iter):
         max_tweet_id = None
 

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -525,10 +525,8 @@ class TwitterHarvester(BaseHarvester):
             self.process_search_warc_2(warc_filepath)
         elif harvest_type == "twitter_filter":
             self._process_tweets(TwitterStreamWarcIter(warc_filepath))
-        #code for filter stream
         elif harvest_type == "twitter_filter_stream":
             self._process_tweets_2(TwitterStreamWarcIter2(warc_filepath))
-        #code end for for filter stream
         elif harvest_type == "twitter_sample":
             self._process_tweets(TwitterStreamWarcIter(warc_filepath))
         elif harvest_type == "twitter_user_timeline":

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -75,8 +75,12 @@ def v2_error_handling(f):
             elif title == "UsageCapExceeded":
                 msg = f"Monthly usage cap exceeded with these API credentials. Please check the Twitter Developer portal for more information about your account."
             else:
-                log.debug(resp_json)
-                raise e
+                errors = [error.get("message", "") for error in resp_json.get("errors", [])]
+                if any(errors):
+                   errors = "; ".join(errors)
+                else:
+                    errors = "None provided." 
+                msg = f"{resp_json.get('detail', 'Error Details')}: {errors}"
             title = title.replace(" ", "_")
             self.result.errors.append(Msg(f"harvest_{title}", msg))
             self.result.success = False

--- a/twitter_harvester.py
+++ b/twitter_harvester.py
@@ -218,13 +218,13 @@ class TwitterHarvester(BaseHarvester):
         seeds = self.message["seeds"]
         # Delete any streaming rules currently in place
         old_rules = self.twarc.get_stream_rules()
-        old_rule_ids = [d['id'] for d in old_rules.get('data')]
+        old_rule_ids = [d['id'] for d in old_rules.get('data', [])]
         log.debug(f'Deleting rules {old_rule_ids}.')
         if old_rule_ids:
             self.twarc.delete_stream_rule_ids(old_rule_ids)
         # Add each seed as a streaming rule
         # TO DO --> Implement user-added tags
-        new_rules = [{"value": seed["token"].get("track") } for seed in seeds]
+        new_rules = [{"value": seed["token"].get("rule"), "tag": seed["token"].get("rule") } for seed in seeds]
         log.debug(f'Adding rules {new_rules}')
         # TO DO --> Handle errors when rule limit reached
         self.twarc.add_stream_rules(new_rules)

--- a/twitter_rest_warc_iter.py
+++ b/twitter_rest_warc_iter.py
@@ -74,7 +74,7 @@ class TwitterRestWarcIter2(BaseWarcIter):
         return ["twitter_status"]
 
     def _select_item(self, item):
-        if not self.limit_user_ids or item.get("user", {}).get("id_str") in self.limit_user_ids:
+        if not self.limit_user_ids or item.get("author_id") in self.limit_user_ids:
             return True
         return False
 

--- a/twitter_stream_exporter.py
+++ b/twitter_stream_exporter.py
@@ -3,6 +3,8 @@ from twitter_stream_warc_iter import TwitterStreamWarcIter
 from twitter_stream_warc_iter import TwitterStreamWarcIter2
 from twitter_rest_exporter import BaseTwitterStatusTable
 from twitter_rest_exporter import BaseTwitterTwoStatusTable
+import argparse
+import sys
 
 
 import logging
@@ -59,7 +61,7 @@ if __name__ == "__main__":
     args, extras = parser.parse_known_args()
     sys.argv = sys.argv[:1] + extras
     if args.twitter_version == '2':
-        TwitterRestExporter2.main(TwitterRestExporter2, QUEUE2, [FILTER_STREAM_ROUTING_KEY])
+        TwitterStreamExporter2.main(TwitterStreamExporter2, QUEUE2, [FILTER_STREAM_ROUTING_KEY])
     else:
-        TwitterRestExporter.main(TwitterRestExporter, QUEUE,
+        TwitterStreamExporter.main(TwitterStreamExporter, QUEUE,
                              [FILTER_ROUTING_KEY, SAMPLE_ROUTING_KEY])

--- a/twitter_stream_exporter.py
+++ b/twitter_stream_exporter.py
@@ -1,14 +1,19 @@
 from sfmutils.exporter import BaseExporter
 from twitter_stream_warc_iter import TwitterStreamWarcIter
+from twitter_stream_warc_iter import TwitterStreamWarcIter2
 from twitter_rest_exporter import BaseTwitterStatusTable
+from twitter_rest_exporter import BaseTwitterTwoStatusTable
+
 
 import logging
 
 log = logging.getLogger(__name__)
 
 QUEUE = "twitter_stream_exporter"
+QUEUE2 = "twitter_stream_exporter2"
 FILTER_ROUTING_KEY = "export.start.twitter.twitter_filter"
 SAMPLE_ROUTING_KEY = "export.start.twitter.twitter_sample"
+FILTER_STREAM_ROUTING_KEY = "harvest.start.twitter2.twitter_filter_stream"
 
 
 class TwitterStreamStatusTable(BaseTwitterStatusTable):
@@ -23,5 +28,38 @@ class TwitterStreamExporter(BaseExporter):
         BaseExporter.__init__(self, api_base_url, TwitterStreamWarcIter, TwitterStreamStatusTable, working_path,
                               mq_config=mq_config, warc_base_path=warc_base_path)
 
+
+#for ver2
+
+class TwitterStreamStatusTable2(BaseTwitterStatusTable):
+    def __init__(self, warc_paths, dedupe, item_date_start, item_date_end, seed_uids, segment_row_size=None):
+        BaseTwitterTwoStatusTable.__init__(self, warc_paths, dedupe, item_date_start, item_date_end, seed_uids,
+                                        TwitterStreamWarcIter2, segment_row_size)
+
+
+class TwitterStreamExporter2(BaseExporter):
+    def __init__(self, api_base_url, working_path, mq_config=None, warc_base_path=None):
+        log.info("Initing TwitterStreamExporter2")
+        BaseExporter.__init__(self, api_base_url, TwitterStreamWarcIter2, TwitterStreamStatusTable2, working_path,
+                              mq_config=mq_config, warc_base_path=warc_base_path)
+
+#for ver2
+
+# if __name__ == "__main__":
+#     TwitterStreamExporter.main(TwitterStreamExporter, QUEUE, [FILTER_ROUTING_KEY, SAMPLE_ROUTING_KEY])
+
+
+#for ver2
+
 if __name__ == "__main__":
-    TwitterStreamExporter.main(TwitterStreamExporter, QUEUE, [FILTER_ROUTING_KEY, SAMPLE_ROUTING_KEY])
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--twitter_version", default='2')
+    # To remove argument before passing to the wrapped function
+    # Following example here: https://stackoverflow.com/questions/35733262/is-there-any-way-to-instruct-argparse-python-2-7-to-remove-found-arguments-fro
+    args, extras = parser.parse_known_args()
+    sys.argv = sys.argv[:1] + extras
+    if args.twitter_version == '2':
+        TwitterRestExporter2.main(TwitterRestExporter2, QUEUE2, [FILTER_STREAM_ROUTING_KEY])
+    else:
+        TwitterRestExporter.main(TwitterRestExporter, QUEUE,
+                             [FILTER_ROUTING_KEY, SAMPLE_ROUTING_KEY])

--- a/twitter_stream_exporter.py
+++ b/twitter_stream_exporter.py
@@ -1,8 +1,6 @@
 from sfmutils.exporter import BaseExporter
-from twitter_stream_warc_iter import TwitterStreamWarcIter
-from twitter_stream_warc_iter import TwitterStreamWarcIter2
-from twitter_rest_exporter import BaseTwitterStatusTable
-from twitter_rest_exporter import BaseTwitterTwoStatusTable
+from twitter_stream_warc_iter import TwitterStreamWarcIter, TwitterStreamWarcIter2
+from twitter_rest_exporter import BaseTwitterStatusTable, BaseTwitterTwoStatusTable, TwitterRestExporter2
 import argparse
 import sys
 
@@ -15,7 +13,7 @@ QUEUE = "twitter_stream_exporter"
 QUEUE2 = "twitter_stream_exporter2"
 FILTER_ROUTING_KEY = "export.start.twitter.twitter_filter"
 SAMPLE_ROUTING_KEY = "export.start.twitter.twitter_sample"
-FILTER_STREAM_ROUTING_KEY = "harvest.start.twitter2.twitter_filter_stream"
+FILTER_STREAM_ROUTING_KEY = "export.start.twitter2.twitter_filter_stream"
 
 
 class TwitterStreamStatusTable(BaseTwitterStatusTable):
@@ -31,27 +29,17 @@ class TwitterStreamExporter(BaseExporter):
                               mq_config=mq_config, warc_base_path=warc_base_path)
 
 
-#for ver2
-
-class TwitterStreamStatusTable2(BaseTwitterStatusTable):
+class TwitterStreamStatusTable2(BaseTwitterTwoStatusTable):
     def __init__(self, warc_paths, dedupe, item_date_start, item_date_end, seed_uids, segment_row_size=None):
         BaseTwitterTwoStatusTable.__init__(self, warc_paths, dedupe, item_date_start, item_date_end, seed_uids,
                                         TwitterStreamWarcIter2, segment_row_size)
 
 
-class TwitterStreamExporter2(BaseExporter):
+class TwitterStreamExporter2(TwitterRestExporter2):
     def __init__(self, api_base_url, working_path, mq_config=None, warc_base_path=None):
         log.info("Initing TwitterStreamExporter2")
         BaseExporter.__init__(self, api_base_url, TwitterStreamWarcIter2, TwitterStreamStatusTable2, working_path,
                               mq_config=mq_config, warc_base_path=warc_base_path)
-
-#for ver2
-
-# if __name__ == "__main__":
-#     TwitterStreamExporter.main(TwitterStreamExporter, QUEUE, [FILTER_ROUTING_KEY, SAMPLE_ROUTING_KEY])
-
-
-#for ver2
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/twitter_stream_warc_iter.py
+++ b/twitter_stream_warc_iter.py
@@ -19,7 +19,6 @@ class TwitterStreamWarcIter(BaseWarcIter):
     def _item_iter(self, url, json_obj):
         # Only want statuses, not deletes, stall_warnings, etc.
         #test for stream
-        #print("filter json object Adhithya Kiran",json_obj)
         if "id_str" in json_obj:
             yield "twitter_status", json_obj["id_str"], date_parse(json_obj["created_at"]), json_obj
         else:
@@ -47,18 +46,19 @@ class TwitterStreamWarcIter2(BaseWarcIter):
         self.limit_user_ids = limit_user_ids                                    #fixed
 
     def _select_record(self, url):
-        return url.startswith("https://api.twitter.com/2")  #fixed(earlier:https://api.twitter.com/2/tweets/search/stream)
+        return url.startswith("https://api.twitter.com/2")  
 
     def _item_iter(self, url, json_obj):
-        # Only want statuses, not deletes, stall_warnings, etc.
-        json_obj = ensure_flattened(json_obj)
-        print("Adhithya Kiran json from warc_iter",json.dumps(json_obj))
-        #print("json_obj Adhithya kiran",json_obj)                                                                   #ensureflattened
+        '''
+        Flattens a list of Tweets and iterates over the list, yielding each Tweet to sfm-utils.warc_iter.BaseWarcIter.iter()
+        '''
+        tweet_list = ensure_flattened(json_obj)
 
-        if "data.id" in json_obj:
-            yield "twitter_status", json_obj["data.id"], date_parse(json_obj["data.created_at"]), json_obj    #created at to data.created at
+        for tweet in tweet_list:
+            if "text" in tweet:
+                yield "twitter_status", tweet["id"], date_parse(tweet["created_at"]), tweet    
         else:
-            yield None, None, None, json_obj
+            yield None, None, None, tweet
 
     @staticmethod
     def item_types():
@@ -76,4 +76,4 @@ class TwitterStreamWarcIter2(BaseWarcIter):
 
 
 if __name__ == "__main__":
-    TwitterStreamWarcIter.main(TwitterStreamWarcIter)         #RESTORED TO 1 FROM 2
+    TwitterStreamWarcIter2.main(TwitterStreamWarcIter2)         

--- a/twitter_stream_warc_iter.py
+++ b/twitter_stream_warc_iter.py
@@ -4,6 +4,9 @@ from __future__ import absolute_import
 from sfmutils.warc_iter import BaseWarcIter
 from dateutil.parser import parse as date_parse
 
+from twarc.expansions import ensure_flattened
+from twarc import Twarc2, expansions
+import json
 
 class TwitterStreamWarcIter(BaseWarcIter):
     def __init__(self, filepaths, limit_user_ids=None):
@@ -15,6 +18,8 @@ class TwitterStreamWarcIter(BaseWarcIter):
 
     def _item_iter(self, url, json_obj):
         # Only want statuses, not deletes, stall_warnings, etc.
+        #test for stream
+        #print("filter json object Adhithya Kiran",json_obj)
         if "id_str" in json_obj:
             yield "twitter_status", json_obj["id_str"], date_parse(json_obj["created_at"]), json_obj
         else:
@@ -34,5 +39,41 @@ class TwitterStreamWarcIter(BaseWarcIter):
         return False
 
 
+#code for stream
+
+class TwitterStreamWarcIter2(BaseWarcIter):
+    def __init__(self, filepaths, limit_user_ids=None):
+        BaseWarcIter.__init__(self, filepaths)
+        self.limit_user_ids = limit_user_ids                                    #fixed
+
+    def _select_record(self, url):
+        return url.startswith("https://api.twitter.com/2")  #fixed(earlier:https://api.twitter.com/2/tweets/search/stream)
+
+    def _item_iter(self, url, json_obj):
+        # Only want statuses, not deletes, stall_warnings, etc.
+        json_obj = ensure_flattened(json_obj)
+        print("Adhithya Kiran json from warc_iter",json.dumps(json_obj))
+        #print("json_obj Adhithya kiran",json_obj)                                                                   #ensureflattened
+
+        if "data.id" in json_obj:
+            yield "twitter_status", json_obj["data.id"], date_parse(json_obj["data.created_at"]), json_obj    #created at to data.created at
+        else:
+            yield None, None, None, json_obj
+
+    @staticmethod
+    def item_types():
+        return ["twitter_status"]
+
+    @property
+    def line_oriented(self):
+        return True
+
+    def _select_item(self, item):                   #user to includes.users
+        if not self.limit_user_ids or item.get("includes.users", {}).get("data.id") in self.limit_user_ids:
+            return True
+        return False
+
+
+
 if __name__ == "__main__":
-    TwitterStreamWarcIter.main(TwitterStreamWarcIter)
+    TwitterStreamWarcIter.main(TwitterStreamWarcIter)         #RESTORED TO 1 FROM 2

--- a/twitter_stream_warc_iter.py
+++ b/twitter_stream_warc_iter.py
@@ -67,7 +67,8 @@ class TwitterStreamWarcIter2(BaseWarcIter):
     def line_oriented(self):
         return True
 
-    def _select_item(self, item):                   #user to includes.users
+    def _select_item(self, item):    
+        # TO DO: check these keys --> They may not be accurate anymore              
         if not self.limit_user_ids or item.get("includes.users", {}).get("data.id") in self.limit_user_ids:
             return True
         return False

--- a/twitter_stream_warc_iter.py
+++ b/twitter_stream_warc_iter.py
@@ -38,8 +38,6 @@ class TwitterStreamWarcIter(BaseWarcIter):
         return False
 
 
-#code for stream
-
 class TwitterStreamWarcIter2(BaseWarcIter):
     def __init__(self, filepaths, limit_user_ids=None):
         BaseWarcIter.__init__(self, filepaths)
@@ -55,10 +53,11 @@ class TwitterStreamWarcIter2(BaseWarcIter):
         tweet_list = ensure_flattened(json_obj)
 
         for tweet in tweet_list:
+            # TO DO: Test if this condition works to yield only the records with content
             if "text" in tweet:
                 yield "twitter_status", tweet["id"], date_parse(tweet["created_at"]), tweet    
-        else:
-            yield None, None, None, tweet
+            else:
+                yield None, None, None, tweet
 
     @staticmethod
     def item_types():
@@ -74,6 +73,7 @@ class TwitterStreamWarcIter2(BaseWarcIter):
         return False
 
 
-
+# TO DO: Need a way to invoke either 1 or 2, depending on the case 
+# Consider implementing with command-line args
 if __name__ == "__main__":
     TwitterStreamWarcIter2.main(TwitterStreamWarcIter2)         


### PR DESCRIPTION
Resolves gwu-libraries/sfm-ui#1104

### Contains
- Upgrade to twarc 2.13, twarc-csv 0.7
- Added new Dockerfile for Twitter stream exporter (v2 exports)
- twitter_harvester.py
  - Added error handling/user-friendly error messages for v.2 API error codes
  - Added support for v.2 streaming rules: 
    - New seeds are treated as additions to the rules
    - Any rules registered not present in the current active seeds are deleted via API
    - Error handlings for rules cap exceeded (cap varies by API access level)
- twitter_rest_warc_iter.py
  - Fixed issue whereby filtering by Twitter User ID wasn't working
- twitter_stream_warc_iter.py
  - Support for iterating over Twitter v.2 JSON (from Filtered Stream API)
  - Note that filtering results by Twitter User ID is not currently supported for this harvest type
- twitter_stream_exporter.py
  - Added logic to delegate to the appropriate version (instance) of the stream exporter, v.1 or v. 2

### Testing
- Harvesting
  - Without Academic Search credentials, create a collection of this type and turn on harvesting. Verify that an appropriate error message is displayed and that the harvest is turned off
  - Verify (from UI and logs) that a Filtered Stream harvest runs and collects Tweets
  - Verify that stopping and starting a Filtered Stream collection from the UI has the intended effect
  - Add more streaming rules than allowed by your API access level -- verify that the appropriate warning appears in the SFM UI
  - Remove streaming rules via the UI and verify that the rules are updated prior to the next harvest (can use the twarc2 command-line utility to check this)
- Exporting
  - Perform exports (all types) from a Filtered Stream collection
  - Verify that the number of Tweets recorded in the UI matches the number in the export
  - Verify that streaming rules appear in the exported results
  - Verify that limiting an export by harvest and item date works as expected


### Testing